### PR TITLE
Add (nightly) no_std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,11 @@ circle-ci = { repository = "vislyhq/stretch", branch = "master" }
 maintenance = { status = "experimental" }
 
 [dependencies]
-ref_eq = "1.0.0"
+libm = "0.1.2"
+
+[features]
+default = ["std"]
+std = []
 
 [dev-dependencies]
 criterion = "0.2"

--- a/src/algo.rs
+++ b/src/algo.rs
@@ -1,7 +1,12 @@
-use ref_eq::ref_eq;
-use std::f32;
+#[cfg(not(feature = "std"))]
+use alloc::{vec, vec::Vec};
+#[cfg(not(feature = "std"))]
+use libm::F32Ext;
+
+use core::f32;
 
 use crate::layout;
+use crate::ref_eq::ref_eq;
 
 use crate::style;
 use crate::style::*;

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -1,4 +1,4 @@
-use std::ops::Add;
+use core::ops::Add;
 
 use crate::number::Number;
 use crate::style;

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use crate::geometry::{Point, Size};
 
 #[derive(Debug, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,13 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), feature(alloc))]
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 pub mod geometry;
 pub mod layout;
 pub mod number;
 pub mod style;
 
 mod algo;
+mod ref_eq;
 pub use crate::algo::compute;

--- a/src/number.rs
+++ b/src/number.rs
@@ -1,4 +1,4 @@
-use std::ops;
+use core::ops;
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum Number {

--- a/src/ref_eq.rs
+++ b/src/ref_eq.rs
@@ -1,0 +1,5 @@
+/// Determine if two borrowed pointers point to the same thing.
+#[inline]
+pub fn ref_eq<'a, 'b, T>(thing: &'a T, other: &'b T) -> bool {
+    (thing as *const T) == (other as *const T)
+}

--- a/src/style.rs
+++ b/src/style.rs
@@ -1,3 +1,8 @@
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+#[cfg(not(feature = "std"))]
+use alloc::{vec, vec::Vec};
+
 use crate::algo;
 use crate::geometry::{Rect, Size};
 use crate::number::Number;
@@ -246,7 +251,7 @@ pub struct Node {
 
     pub children: Vec<Node>,
 
-    pub layout_cache: std::cell::RefCell<Option<LayoutCache>>,
+    pub layout_cache: core::cell::RefCell<Option<LayoutCache>>,
 }
 
 impl Default for Node {
@@ -285,7 +290,7 @@ impl Default for Node {
 
             children: vec![],
 
-            layout_cache: std::cell::RefCell::new(None),
+            layout_cache: core::cell::RefCell::new(None),
         }
     }
 }


### PR DESCRIPTION
Fixes #10.

- Inlined the `ref_eq` dependency, since that crate did not have `no_std` support and was only a single function
- I had to add a dependency on `libm`, since `core` is currently lacking maths capabilites. See [this RFC](https://github.com/rust-lang/rfcs/issues/2505)