### PR TITLE
Fixes percentage height calculation

### DIFF
--- a/src/algo.rs
+++ b/src/algo.rs
@@ -355,17 +355,12 @@ fn compute_internal(
         // webkit handled various scenarios. Can probably be solved better by passing in
         // min-content max-content constraints fromt the top
         let min_main = if is_row {
-            compute_internal(
-                child.node,
-                Size { width: Undefined, height: Undefined },
-                available_space,
-                false,
-            )
-            .size
-            .width
-            .maybe_max(child.min_size.width)
-            .maybe_min(child.size.width)
-            .to_number()
+            compute_internal(child.node, Size { width: Undefined, height: Undefined }, available_space, false)
+                .size
+                .width
+                .maybe_max(child.min_size.width)
+                .maybe_min(child.size.width)
+                .to_number()
         } else {
             child.min_size.main(dir)
         };
@@ -594,17 +589,12 @@ fn compute_internal(
                 // min-content max-content constraints fromt the top. Need to figure out correct thing to do here as
                 // just piling on more conditionals.
                 let min_main = if is_row && child.node.measure.is_none() {
-                    compute_internal(
-                        child.node,
-                        Size { width: Undefined, height: Undefined },
-                        available_space,
-                        false,
-                    )
-                    .size
-                    .width
-                    .maybe_min(child.size.width)
-                    .maybe_max(child.min_size.width)
-                    .to_number()
+                    compute_internal(child.node, Size { width: Undefined, height: Undefined }, available_space, false)
+                        .size
+                        .width
+                        .maybe_min(child.size.width)
+                        .maybe_max(child.min_size.width)
+                        .to_number()
                 } else {
                     child.min_size.main(dir)
                 };
@@ -1039,12 +1029,7 @@ fn compute_internal(
     // layout we are done now.
     if !perform_layout {
         let result = ComputeResult { size: container_size, children: vec![] };
-        node.layout_cache.replace(Some(LayoutCache {
-            node_size,
-            parent_size,
-            perform_layout,
-            result: result.clone(),
-        }));
+        node.layout_cache.replace(Some(LayoutCache { node_size, parent_size, perform_layout, result: result.clone() }));
         return result;
     }
 
@@ -1317,11 +1302,6 @@ fn compute_internal(
     children.sort_by(|c1, c2| c1.order.cmp(&c2.order));
 
     let result = ComputeResult { size: container_size, children };
-    node.layout_cache.replace(Some(LayoutCache {
-        node_size,
-        parent_size,
-        perform_layout,
-        result: result.clone(),
-    }));
+    node.layout_cache.replace(Some(LayoutCache { node_size, parent_size, perform_layout, result: result.clone() }));
     result
 }

--- a/src/ref_eq.rs
+++ b/src/ref_eq.rs
@@ -1,5 +1,5 @@
 /// Determine if two borrowed pointers point to the same thing.
 #[inline]
-pub fn ref_eq<'a, 'b, T>(thing: &'a T, other: &'b T) -> bool {
+pub fn ref_eq<T>(thing: &T, other: &T) -> bool {
     (thing as *const T) == (other as *const T)
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -211,7 +211,6 @@ type MeasureFunc = Box<Fn(Size<Number>) -> Size<f32>>;
 pub struct LayoutCache {
     pub node_size: Size<Number>,
     pub parent_size: Size<Number>,
-    pub percent_calc_base: Number,
     pub perform_layout: bool,
 
     pub result: algo::ComputeResult,

--- a/test_fixtures/percentage_flex_basis_cross.html
+++ b/test_fixtures/percentage_flex_basis_cross.html
@@ -9,7 +9,7 @@
 <head/>
 <body>
 
-<div id="test-root" style="width: 200px; height: 200px; flex-direction: column;">
+<div id="test-root" style="width: 200px; height: 400px; flex-direction: column;">
   <div style="flex-grow: 1; flex-basis: 50%;"></div>
   <div style="flex-grow: 1; flex-basis: 25%;"></div>
 </div>

--- a/test_fixtures/percentage_flex_basis_cross_max_height.html
+++ b/test_fixtures/percentage_flex_basis_cross_max_height.html
@@ -9,7 +9,7 @@
 <head/>
 <body>
 
-<div id="test-root" style="width: 200px; height: 200px; flex-direction: column;">
+<div id="test-root" style="width: 200px; height: 400px; flex-direction: column;">
   <div style="flex-grow: 1; flex-basis: 10%; max-height: 60%;"></div>
   <div style="flex-grow: 4; flex-basis: 10%; max-height: 20%;"></div>
 </div>

--- a/test_fixtures/percentage_flex_basis_cross_max_width.html
+++ b/test_fixtures/percentage_flex_basis_cross_max_width.html
@@ -9,7 +9,7 @@
 <head/>
 <body>
 
-<div id="test-root" style="width: 200px; height: 200px; flex-direction: column;">
+<div id="test-root" style="width: 200px; height: 400px; flex-direction: column;">
   <div style="flex-grow: 1; flex-basis: 10%; max-width: 60%;"></div>
   <div style="flex-grow: 4; flex-basis: 15%; max-width: 20%;"></div>
 </div>

--- a/test_fixtures/percentage_flex_basis_cross_min_height.html
+++ b/test_fixtures/percentage_flex_basis_cross_min_height.html
@@ -9,7 +9,7 @@
 <head/>
 <body>
 
-<div id="test-root" style="width: 200px; height: 200px; flex-direction: column;">
+<div id="test-root" style="width: 200px; height: 400px; flex-direction: column;">
   <div style="flex-grow: 1; min-height: 60%;"></div>
   <div style="flex-grow: 2; min-height: 10%;"></div>
 </div>

--- a/test_fixtures/percentage_flex_basis_cross_min_width.html
+++ b/test_fixtures/percentage_flex_basis_cross_min_width.html
@@ -9,7 +9,7 @@
 <head/>
 <body>
 
-<div id="test-root" style="width: 200px; height: 200px; flex-direction: column;">
+<div id="test-root" style="width: 200px; height: 400px; flex-direction: column;">
   <div style="flex-grow: 1; flex-basis: 10%; min-width: 60%;"></div>
   <div style="flex-grow: 4; flex-basis: 15%; min-width: 20%;"></div>
 </div>

--- a/test_fixtures/percentage_flex_basis_main_max_height.html
+++ b/test_fixtures/percentage_flex_basis_main_max_height.html
@@ -9,7 +9,7 @@
 <head/>
 <body>
 
-<div id="test-root" style="width: 200px; height: 200px; flex-direction: row;">
+<div id="test-root" style="width: 200px; height: 400px; flex-direction: row;">
   <div style="flex-grow: 1; flex-basis: 10%; max-height: 60%;"></div>
   <div style="flex-grow: 4; flex-basis: 10%; max-height: 20%;"></div>
 </div>

--- a/test_fixtures/percentage_flex_basis_main_max_width.html
+++ b/test_fixtures/percentage_flex_basis_main_max_width.html
@@ -9,7 +9,7 @@
 <head/>
 <body>
 
-<div id="test-root" style="width: 200px; height: 200px; flex-direction: row;">
+<div id="test-root" style="width: 200px; height: 400px; flex-direction: row;">
   <div style="flex-grow: 1; flex-basis: 15%; max-width: 60%;"></div>
   <div style="flex-grow: 4; flex-basis: 10%; max-width: 20%;"></div>
 </div>

--- a/test_fixtures/percentage_flex_basis_main_min_width.html
+++ b/test_fixtures/percentage_flex_basis_main_min_width.html
@@ -9,7 +9,7 @@
 <head/>
 <body>
 
-<div id="test-root" style="width: 200px; height: 200px; flex-direction: row;">
+<div id="test-root" style="width: 200px; height: 400px; flex-direction: row;">
   <div style="flex-grow: 1; flex-basis: 15%; min-width: 60%;"></div>
   <div style="flex-grow: 4; flex-basis: 10%; min-width: 20%;"></div>
 </div>

--- a/test_fixtures/percentage_size_based_on_parent_inner_size.html
+++ b/test_fixtures/percentage_size_based_on_parent_inner_size.html
@@ -9,7 +9,7 @@
 <head/>
 <body>
 
-<div id="test-root" style="width: 200px; height: 200px; padding: 20px; flex-direction: column;">
+<div id="test-root" style="width: 200px; height: 400px; padding: 20px; flex-direction: column;">
   <div style="width: 50%; height: 50%;"></div>
 </div>
 

--- a/test_fixtures/percentage_width_height.html
+++ b/test_fixtures/percentage_width_height.html
@@ -9,7 +9,7 @@
 <head/>
 <body>
 
-<div id="test-root" style="width: 200px; height: 200px; flex-direction: row;">
+<div id="test-root" style="width: 200px; height: 400px; flex-direction: row;">
   <div style="width: 30%; height: 30%;"></div>
 </div>
 

--- a/tests/generated.rs
+++ b/tests/generated.rs
@@ -3072,7 +3072,7 @@ mod generated {
             &stretch::style::Node {
                 size: stretch::geometry::Size {
                     width: stretch::style::Dimension::Points(200.0000),
-                    height: stretch::style::Dimension::Points(200.0000),
+                    height: stretch::style::Dimension::Points(400.0000),
                     ..Default::default()
                 },
                 children: vec![
@@ -3101,17 +3101,17 @@ mod generated {
         );
 
         assert_eq!(layout.size.width, 200.0000);
-        assert_eq!(layout.size.height, 200.0000);
+        assert_eq!(layout.size.height, 400.0000);
         assert_eq!(layout.location.x, 0.0000);
         assert_eq!(layout.location.y, 0.0000);
 
         assert_eq!(layout.children[0].size.width, 120.0000);
-        assert_eq!(layout.children[0].size.height, 200.0000);
+        assert_eq!(layout.children[0].size.height, 400.0000);
         assert_eq!(layout.children[0].location.x, 0.0000);
         assert_eq!(layout.children[0].location.y, 0.0000);
 
         assert_eq!(layout.children[1].size.width, 40.0000);
-        assert_eq!(layout.children[1].size.height, 200.0000);
+        assert_eq!(layout.children[1].size.height, 400.0000);
         assert_eq!(layout.children[1].location.x, 120.0000);
         assert_eq!(layout.children[1].location.y, 0.0000);
     }
@@ -3428,7 +3428,7 @@ mod generated {
                 flex_direction: stretch::style::FlexDirection::Column,
                 size: stretch::geometry::Size {
                     width: stretch::style::Dimension::Points(200.0000),
-                    height: stretch::style::Dimension::Points(200.0000),
+                    height: stretch::style::Dimension::Points(400.0000),
                     ..Default::default()
                 },
                 children: vec![
@@ -3449,19 +3449,19 @@ mod generated {
         );
 
         assert_eq!(layout.size.width, 200.0000);
-        assert_eq!(layout.size.height, 200.0000);
+        assert_eq!(layout.size.height, 400.0000);
         assert_eq!(layout.location.x, 0.0000);
         assert_eq!(layout.location.y, 0.0000);
 
         assert_eq!(layout.children[0].size.width, 200.0000);
-        assert_eq!(layout.children[0].size.height, 125.0000);
+        assert_eq!(layout.children[0].size.height, 250.0000);
         assert_eq!(layout.children[0].location.x, 0.0000);
         assert_eq!(layout.children[0].location.y, 0.0000);
 
         assert_eq!(layout.children[1].size.width, 200.0000);
-        assert_eq!(layout.children[1].size.height, 75.0000);
+        assert_eq!(layout.children[1].size.height, 150.0000);
         assert_eq!(layout.children[1].location.x, 0.0000);
-        assert_eq!(layout.children[1].location.y, 125.0000);
+        assert_eq!(layout.children[1].location.y, 250.0000);
     }
 
     #[test]
@@ -3958,7 +3958,7 @@ mod generated {
                 flex_direction: stretch::style::FlexDirection::Column,
                 size: stretch::geometry::Size {
                     width: stretch::style::Dimension::Points(200.0000),
-                    height: stretch::style::Dimension::Points(200.0000),
+                    height: stretch::style::Dimension::Points(400.0000),
                     ..Default::default()
                 },
                 children: vec![
@@ -3987,19 +3987,19 @@ mod generated {
         );
 
         assert_eq!(layout.size.width, 200.0000);
-        assert_eq!(layout.size.height, 200.0000);
+        assert_eq!(layout.size.height, 400.0000);
         assert_eq!(layout.location.x, 0.0000);
         assert_eq!(layout.location.y, 0.0000);
 
         assert_eq!(layout.children[0].size.width, 120.0000);
-        assert_eq!(layout.children[0].size.height, 50.0000);
+        assert_eq!(layout.children[0].size.height, 100.0000);
         assert_eq!(layout.children[0].location.x, 0.0000);
         assert_eq!(layout.children[0].location.y, 0.0000);
 
         assert_eq!(layout.children[1].size.width, 40.0000);
-        assert_eq!(layout.children[1].size.height, 150.0000);
+        assert_eq!(layout.children[1].size.height, 300.0000);
         assert_eq!(layout.children[1].location.x, 0.0000);
-        assert_eq!(layout.children[1].location.y, 50.0000);
+        assert_eq!(layout.children[1].location.y, 100.0000);
     }
 
     #[test]
@@ -4499,7 +4499,7 @@ mod generated {
                 flex_direction: stretch::style::FlexDirection::Column,
                 size: stretch::geometry::Size {
                     width: stretch::style::Dimension::Points(200.0000),
-                    height: stretch::style::Dimension::Points(200.0000),
+                    height: stretch::style::Dimension::Points(400.0000),
                     ..Default::default()
                 },
                 children: vec![
@@ -4526,19 +4526,19 @@ mod generated {
         );
 
         assert_eq!(layout.size.width, 200.0000);
-        assert_eq!(layout.size.height, 200.0000);
+        assert_eq!(layout.size.height, 400.0000);
         assert_eq!(layout.location.x, 0.0000);
         assert_eq!(layout.location.y, 0.0000);
 
         assert_eq!(layout.children[0].size.width, 200.0000);
-        assert_eq!(layout.children[0].size.height, 140.0000);
+        assert_eq!(layout.children[0].size.height, 280.0000);
         assert_eq!(layout.children[0].location.x, 0.0000);
         assert_eq!(layout.children[0].location.y, 0.0000);
 
         assert_eq!(layout.children[1].size.width, 200.0000);
-        assert_eq!(layout.children[1].size.height, 60.0000);
+        assert_eq!(layout.children[1].size.height, 120.0000);
         assert_eq!(layout.children[1].location.x, 0.0000);
-        assert_eq!(layout.children[1].location.y, 140.0000);
+        assert_eq!(layout.children[1].location.y, 280.0000);
     }
 
     #[test]
@@ -4761,7 +4761,7 @@ mod generated {
             &stretch::style::Node {
                 size: stretch::geometry::Size {
                     width: stretch::style::Dimension::Points(200.0000),
-                    height: stretch::style::Dimension::Points(200.0000),
+                    height: stretch::style::Dimension::Points(400.0000),
                     ..Default::default()
                 },
                 children: vec![stretch::style::Node {
@@ -4778,12 +4778,12 @@ mod generated {
         );
 
         assert_eq!(layout.size.width, 200.0000);
-        assert_eq!(layout.size.height, 200.0000);
+        assert_eq!(layout.size.height, 400.0000);
         assert_eq!(layout.location.x, 0.0000);
         assert_eq!(layout.location.y, 0.0000);
 
         assert_eq!(layout.children[0].size.width, 60.0000);
-        assert_eq!(layout.children[0].size.height, 60.0000);
+        assert_eq!(layout.children[0].size.height, 120.0000);
         assert_eq!(layout.children[0].location.x, 0.0000);
         assert_eq!(layout.children[0].location.y, 0.0000);
     }
@@ -6044,7 +6044,7 @@ mod generated {
                 flex_direction: stretch::style::FlexDirection::Column,
                 size: stretch::geometry::Size {
                     width: stretch::style::Dimension::Points(200.0000),
-                    height: stretch::style::Dimension::Points(200.0000),
+                    height: stretch::style::Dimension::Points(400.0000),
                     ..Default::default()
                 },
                 padding: stretch::geometry::Rect {
@@ -6068,12 +6068,12 @@ mod generated {
         );
 
         assert_eq!(layout.size.width, 200.0000);
-        assert_eq!(layout.size.height, 200.0000);
+        assert_eq!(layout.size.height, 400.0000);
         assert_eq!(layout.location.x, 0.0000);
         assert_eq!(layout.location.y, 0.0000);
 
         assert_eq!(layout.children[0].size.width, 80.0000);
-        assert_eq!(layout.children[0].size.height, 80.0000);
+        assert_eq!(layout.children[0].size.height, 180.0000);
         assert_eq!(layout.children[0].location.x, 20.0000);
         assert_eq!(layout.children[0].location.y, 20.0000);
     }
@@ -8472,7 +8472,7 @@ mod generated {
             &stretch::style::Node {
                 size: stretch::geometry::Size {
                     width: stretch::style::Dimension::Points(200.0000),
-                    height: stretch::style::Dimension::Points(200.0000),
+                    height: stretch::style::Dimension::Points(400.0000),
                     ..Default::default()
                 },
                 children: vec![
@@ -8501,17 +8501,17 @@ mod generated {
         );
 
         assert_eq!(layout.size.width, 200.0000);
-        assert_eq!(layout.size.height, 200.0000);
+        assert_eq!(layout.size.height, 400.0000);
         assert_eq!(layout.location.x, 0.0000);
         assert_eq!(layout.location.y, 0.0000);
 
         assert_eq!(layout.children[0].size.width, 52.0000);
-        assert_eq!(layout.children[0].size.height, 120.0000);
+        assert_eq!(layout.children[0].size.height, 240.0000);
         assert_eq!(layout.children[0].location.x, 0.0000);
         assert_eq!(layout.children[0].location.y, 0.0000);
 
         assert_eq!(layout.children[1].size.width, 148.0000);
-        assert_eq!(layout.children[1].size.height, 40.0000);
+        assert_eq!(layout.children[1].size.height, 80.0000);
         assert_eq!(layout.children[1].location.x, 52.0000);
         assert_eq!(layout.children[1].location.y, 0.0000);
     }
@@ -9270,7 +9270,7 @@ mod generated {
             &stretch::style::Node {
                 size: stretch::geometry::Size {
                     width: stretch::style::Dimension::Points(200.0000),
-                    height: stretch::style::Dimension::Points(200.0000),
+                    height: stretch::style::Dimension::Points(400.0000),
                     ..Default::default()
                 },
                 children: vec![
@@ -9299,17 +9299,17 @@ mod generated {
         );
 
         assert_eq!(layout.size.width, 200.0000);
-        assert_eq!(layout.size.height, 200.0000);
+        assert_eq!(layout.size.height, 400.0000);
         assert_eq!(layout.location.x, 0.0000);
         assert_eq!(layout.location.y, 0.0000);
 
         assert_eq!(layout.children[0].size.width, 120.0000);
-        assert_eq!(layout.children[0].size.height, 200.0000);
+        assert_eq!(layout.children[0].size.height, 400.0000);
         assert_eq!(layout.children[0].location.x, 0.0000);
         assert_eq!(layout.children[0].location.y, 0.0000);
 
         assert_eq!(layout.children[1].size.width, 80.0000);
-        assert_eq!(layout.children[1].size.height, 200.0000);
+        assert_eq!(layout.children[1].size.height, 400.0000);
         assert_eq!(layout.children[1].location.x, 120.0000);
         assert_eq!(layout.children[1].location.y, 0.0000);
     }
@@ -10099,7 +10099,7 @@ mod generated {
                 flex_direction: stretch::style::FlexDirection::Column,
                 size: stretch::geometry::Size {
                     width: stretch::style::Dimension::Points(200.0000),
-                    height: stretch::style::Dimension::Points(200.0000),
+                    height: stretch::style::Dimension::Points(400.0000),
                     ..Default::default()
                 },
                 children: vec![
@@ -10128,19 +10128,19 @@ mod generated {
         );
 
         assert_eq!(layout.size.width, 200.0000);
-        assert_eq!(layout.size.height, 200.0000);
+        assert_eq!(layout.size.height, 400.0000);
         assert_eq!(layout.location.x, 0.0000);
         assert_eq!(layout.location.y, 0.0000);
 
         assert_eq!(layout.children[0].size.width, 200.0000);
-        assert_eq!(layout.children[0].size.height, 50.0000);
+        assert_eq!(layout.children[0].size.height, 100.0000);
         assert_eq!(layout.children[0].location.x, 0.0000);
         assert_eq!(layout.children[0].location.y, 0.0000);
 
         assert_eq!(layout.children[1].size.width, 200.0000);
-        assert_eq!(layout.children[1].size.height, 150.0000);
+        assert_eq!(layout.children[1].size.height, 300.0000);
         assert_eq!(layout.children[1].location.x, 0.0000);
-        assert_eq!(layout.children[1].location.y, 50.0000);
+        assert_eq!(layout.children[1].location.y, 100.0000);
     }
 
     #[test]
@@ -10288,7 +10288,7 @@ mod generated {
                 flex_direction: stretch::style::FlexDirection::Column,
                 size: stretch::geometry::Size {
                     width: stretch::style::Dimension::Points(200.0000),
-                    height: stretch::style::Dimension::Points(200.0000),
+                    height: stretch::style::Dimension::Points(400.0000),
                     ..Default::default()
                 },
                 children: vec![
@@ -10317,19 +10317,19 @@ mod generated {
         );
 
         assert_eq!(layout.size.width, 200.0000);
-        assert_eq!(layout.size.height, 200.0000);
+        assert_eq!(layout.size.height, 400.0000);
         assert_eq!(layout.location.x, 0.0000);
         assert_eq!(layout.location.y, 0.0000);
 
         assert_eq!(layout.children[0].size.width, 200.0000);
-        assert_eq!(layout.children[0].size.height, 120.0000);
+        assert_eq!(layout.children[0].size.height, 240.0000);
         assert_eq!(layout.children[0].location.x, 0.0000);
         assert_eq!(layout.children[0].location.y, 0.0000);
 
         assert_eq!(layout.children[1].size.width, 200.0000);
-        assert_eq!(layout.children[1].size.height, 40.0000);
+        assert_eq!(layout.children[1].size.height, 80.0000);
         assert_eq!(layout.children[1].location.x, 0.0000);
-        assert_eq!(layout.children[1].location.y, 120.0000);
+        assert_eq!(layout.children[1].location.y, 240.0000);
     }
 
     #[test]


### PR DESCRIPTION
Percentage height calculation should be based on container height not container width. Only margin/border/padding is always based on width.