### PR TITLE
[WIP] Potential alternative API, ECS-ish with `NodeId` and salsa for incremental compute

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,9 @@ circle-ci = { repository = "vislyhq/stretch", branch = "master" }
 maintenance = { status = "experimental" }
 
 [dependencies]
-libm = "0.1.2"
+decorum = "0.1.3"
+num-traits = "0.2"
+salsa = "0.10"
 
 [features]
 default = ["std"]

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -2,19 +2,21 @@ use stretch::geometry::Size;
 use stretch::style::*;
 
 fn main() {
-    let node = Node {
-        size: Size { width: Dimension::Points(100.0), height: Dimension::Points(100.0) },
+    let mut db = stretch::Database::new();
+    let root = db.new_node(Node {
+        size: Size { width: Dimension::Points(100.0.into()), height: Dimension::Points(100.0.into()) },
         justify_content: JustifyContent::Center,
-
-        children: vec![Node {
-            size: Size { width: Dimension::Percent(0.5), height: Dimension::Auto },
-            ..Default::default()
-        }],
-
         ..Default::default()
-    };
+    });
 
-    let layout = stretch::compute(&node, Size::undefined()).unwrap();
+    let half_child = db.new_node(Node {
+        size: Size { width: Dimension::Percent(0.5.into()), height: Dimension::Auto },
+        ..Default::default()
+    });
+
+    db.set_children(root, vec![half_child]);
+
+    let layout = stretch::compute(&mut db, root, Size::undefined()).unwrap();
 
     println!("{:#?}", layout);
 }

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -3,7 +3,7 @@ use core::ops::Add;
 use crate::number::Number;
 use crate::style;
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Debug, Default, Eq, Hash, PartialEq)]
 pub struct Rect<T> {
     pub start: T,
     pub end: T,
@@ -80,7 +80,7 @@ where
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Debug, Default, Eq, Hash, PartialEq)]
 pub struct Size<T> {
     pub width: T,
     pub height: T,
@@ -129,7 +129,7 @@ impl<T> Size<T> {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, Default, Eq, Hash, PartialEq)]
 pub struct Point<T> {
     pub x: T,
     pub y: T,

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -2,11 +2,12 @@
 use alloc::vec::Vec;
 
 use crate::geometry::{Point, Size};
+use decorum::R32;
 
 #[derive(Debug, Clone)]
 pub struct Node {
     pub(crate) order: u32,
-    pub size: Size<f32>,
-    pub location: Point<f32>,
+    pub size: Size<R32>,
+    pub location: Point<R32>,
     pub children: Vec<Node>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,5 +10,4 @@ pub mod result;
 pub mod style;
 
 mod algo;
-mod ref_eq;
-pub use crate::algo::compute;
+pub use crate::algo::{compute, Database};

--- a/src/number.rs
+++ b/src/number.rs
@@ -1,8 +1,9 @@
 use core::ops;
+use decorum::R32;
 
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, Eq, Hash, PartialEq, Debug)]
 pub enum Number {
-    Defined(f32),
+    Defined(R32),
     Undefined,
 }
 
@@ -20,8 +21,8 @@ impl Default for Number {
     }
 }
 
-impl OrElse<f32> for Number {
-    fn or_else(self, other: f32) -> f32 {
+impl OrElse<R32> for Number {
+    fn or_else(self, other: R32) -> R32 {
         match self {
             Number::Defined(val) => val,
             Number::Undefined => other,
@@ -81,15 +82,15 @@ impl MinMax<Number, Number> for Number {
     }
 }
 
-impl MinMax<f32, Number> for Number {
-    fn maybe_min(self, rhs: f32) -> Number {
+impl MinMax<R32, Number> for Number {
+    fn maybe_min(self, rhs: R32) -> Number {
         match self {
             Number::Defined(val) => Number::Defined(val.min(rhs)),
             Number::Undefined => Number::Undefined,
         }
     }
 
-    fn maybe_max(self, rhs: f32) -> Number {
+    fn maybe_max(self, rhs: R32) -> Number {
         match self {
             Number::Defined(val) => Number::Defined(val.max(rhs)),
             Number::Undefined => Number::Undefined,
@@ -97,15 +98,15 @@ impl MinMax<f32, Number> for Number {
     }
 }
 
-impl MinMax<Number, f32> for f32 {
-    fn maybe_min(self, rhs: Number) -> f32 {
+impl MinMax<Number, R32> for R32 {
+    fn maybe_min(self, rhs: Number) -> R32 {
         match rhs {
             Number::Defined(val) => self.min(val),
             Number::Undefined => self,
         }
     }
 
-    fn maybe_max(self, rhs: Number) -> f32 {
+    fn maybe_max(self, rhs: Number) -> R32 {
         match rhs {
             Number::Defined(val) => self.max(val),
             Number::Undefined => self,
@@ -113,16 +114,16 @@ impl MinMax<Number, f32> for f32 {
     }
 }
 
-impl ToNumber for f32 {
+impl ToNumber for R32 {
     fn to_number(self) -> Number {
         Number::Defined(self)
     }
 }
 
-impl ops::Add<f32> for Number {
+impl ops::Add<R32> for Number {
     type Output = Number;
 
-    fn add(self, rhs: f32) -> Number {
+    fn add(self, rhs: R32) -> Number {
         match self {
             Number::Defined(val) => Number::Defined(val + rhs),
             Number::Undefined => Number::Undefined,
@@ -144,10 +145,10 @@ impl ops::Add<Number> for Number {
     }
 }
 
-impl ops::Sub<f32> for Number {
+impl ops::Sub<R32> for Number {
     type Output = Number;
 
-    fn sub(self, rhs: f32) -> Number {
+    fn sub(self, rhs: R32) -> Number {
         match self {
             Number::Defined(val) => Number::Defined(val - rhs),
             Number::Undefined => Number::Undefined,
@@ -169,10 +170,10 @@ impl ops::Sub<Number> for Number {
     }
 }
 
-impl ops::Mul<f32> for Number {
+impl ops::Mul<R32> for Number {
     type Output = Number;
 
-    fn mul(self, rhs: f32) -> Number {
+    fn mul(self, rhs: R32) -> Number {
         match self {
             Number::Defined(val) => Number::Defined(val * rhs),
             Number::Undefined => Number::Undefined,
@@ -194,10 +195,10 @@ impl ops::Mul<Number> for Number {
     }
 }
 
-impl ops::Div<f32> for Number {
+impl ops::Div<R32> for Number {
     type Output = Number;
 
-    fn div(self, rhs: f32) -> Number {
+    fn div(self, rhs: R32) -> Number {
         match self {
             Number::Defined(val) => Number::Defined(val / rhs),
             Number::Undefined => Number::Undefined,

--- a/src/ref_eq.rs
+++ b/src/ref_eq.rs
@@ -1,5 +1,0 @@
-/// Determine if two borrowed pointers point to the same thing.
-#[inline]
-pub fn ref_eq<T>(thing: &T, other: &T) -> bool {
-    (thing as *const T) == (other as *const T)
-}

--- a/src/style.rs
+++ b/src/style.rs
@@ -3,12 +3,13 @@ use alloc::boxed::Box;
 #[cfg(not(feature = "std"))]
 use alloc::{vec, vec::Vec};
 
-use crate::algo;
 use crate::geometry::{Rect, Size};
 use crate::number::Number;
 use crate::result::Result;
 
-#[derive(Copy, Clone, PartialEq, Debug)]
+use decorum::R32;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum AlignItems {
     FlexStart,
     FlexEnd,
@@ -23,7 +24,7 @@ impl Default for AlignItems {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub enum AlignSelf {
     Auto,
     FlexStart,
@@ -39,7 +40,7 @@ impl Default for AlignSelf {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum AlignContent {
     FlexStart,
     FlexEnd,
@@ -55,7 +56,7 @@ impl Default for AlignContent {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Direction {
     Inherit,
     LTR,
@@ -68,7 +69,7 @@ impl Default for Direction {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Display {
     Flex,
     None,
@@ -80,7 +81,7 @@ impl Default for Display {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum FlexDirection {
     Row,
     Column,
@@ -108,7 +109,7 @@ impl FlexDirection {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum JustifyContent {
     FlexStart,
     FlexEnd,
@@ -124,7 +125,7 @@ impl Default for JustifyContent {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Overflow {
     Visible,
     Hidden,
@@ -137,7 +138,7 @@ impl Default for Overflow {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum PositionType {
     Relative,
     Absolute,
@@ -149,7 +150,7 @@ impl Default for PositionType {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum FlexWrap {
     NoWrap,
     Wrap,
@@ -162,12 +163,12 @@ impl Default for FlexWrap {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Dimension {
     Undefined,
     Auto,
-    Points(f32),
-    Percent(f32),
+    Points(R32),
+    Percent(R32),
 }
 
 impl Default for Dimension {
@@ -194,29 +195,11 @@ impl Dimension {
     }
 }
 
-impl Default for Rect<Dimension> {
-    fn default() -> Rect<Dimension> {
-        Rect { start: Default::default(), end: Default::default(), top: Default::default(), bottom: Default::default() }
-    }
-}
+// FIXME(anp): reconcile this before PR!
+// type MeasureFunc = Box<Fn(Size<Number>) -> Result<Size<f32>> + Send + Sync>;
+type MeasureFunc = &'static fn(Size<Number>) -> Result<Size<R32>>;
 
-impl Default for Size<Dimension> {
-    fn default() -> Size<Dimension> {
-        Size { width: Dimension::Auto, height: Dimension::Auto }
-    }
-}
-
-type MeasureFunc = Box<Fn(Size<Number>) -> Result<Size<f32>>>;
-
-#[derive(Debug, Clone)]
-pub struct LayoutCache {
-    pub node_size: Size<Number>,
-    pub parent_size: Size<Number>,
-    pub perform_layout: bool,
-
-    pub result: algo::ComputeResult,
-}
-
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Node {
     pub display: Display,
 
@@ -238,8 +221,8 @@ pub struct Node {
     pub padding: Rect<Dimension>,
     pub border: Rect<Dimension>,
 
-    pub flex_grow: f32,
-    pub flex_shrink: f32,
+    pub flex_grow: R32,
+    pub flex_shrink: R32,
     pub flex_basis: Dimension,
 
     pub size: Size<Dimension>,
@@ -248,10 +231,6 @@ pub struct Node {
 
     pub aspect_ratio: Number,
     pub measure: Option<MeasureFunc>,
-
-    pub children: Vec<Node>,
-
-    pub layout_cache: core::cell::RefCell<Option<LayoutCache>>,
 }
 
 impl Default for Node {
@@ -277,8 +256,8 @@ impl Default for Node {
             padding: Default::default(),
             border: Default::default(),
 
-            flex_grow: 0.0,
-            flex_shrink: 1.0,
+            flex_grow: 0.0.into(),
+            flex_shrink: 1.0.into(),
             flex_basis: Dimension::Auto,
 
             size: Default::default(),
@@ -287,10 +266,6 @@ impl Default for Node {
 
             aspect_ratio: Default::default(),
             measure: None,
-
-            children: vec![],
-
-            layout_cache: core::cell::RefCell::new(None),
         }
     }
 }


### PR DESCRIPTION
Hi! I noticed y'all landed a large refactor recently, so I know this is out of date, but I thought it was still worth throwing up for discussion.

My rough idea here is to use the newer [salsa](https://crates.io/crates/salsa) to get incremental re-layout computation for "free" on top of the currently mostly pure query API of the crate.

A lot more work would be necessary to actually realize the hypothetical benefits of this approach, and there are already some apparent downsides. For example, salsa requires memoized inputs/outputs to impl `Eq + Hash`, which necessitates using a wrapper around `f32` to panic on `Inf/NaN`. In this case I chose to try the `decorum` crate but it might be preferable even to dodge a dependency and maintain a stretch-specific float type that implements `Eq + Hash` and bans non-real values. Also, the changed shape of the API would require clients to store a database struct in addition to the layout nodes they store to integrate UI components with the library. This change also breaks the no_std support for the time being (although I think there are probably ways to make that work again?).

However, I think the upside could be kind of cool? For one thing, nodes can be represented by simple integers stored separately from the styles currently assigned to them. This representation is nice for FFI and for Rust clients for a number of reasons, including being able to reference nodes from multiple locations without running afoul of the borrow checker or adding a lot of smart pointers. For another, it's fairly likely that as salsa matures whole classes of state invalidation bugs would become more or less impossible in the layout library. It might be possible to memoize layout results at a finer granularity than a single node for example, as salsa allows defining intermediate computations as cached based on inputs as well.

What do you think? Is this worth investigating further?