### PR TITLE
Fix a typo in Swift docs

### DIFF
--- a/docs/src/pages/docs/swift.mdx
+++ b/docs/src/pages/docs/swift.mdx
@@ -146,7 +146,7 @@ Marks the node as dirty and propagates this up the node tree. This function is c
 
 ----
 
-Returns whether of not this node is marked as dirty and will need to be recalculated during the next layout pass.
+Returns whether or not this node is marked as dirty and will need to be recalculated during the next layout pass.
 
 <Code lang="swift">{`var dirty: Bool`}</Code>
 


### PR DESCRIPTION
Noticed a small typo in the Swift docs so thought I'd submit a PR. Awesome project!