### PR TITLE
Fix another typo in the Swift docs

### DIFF
--- a/docs/src/pages/docs/swift.mdx
+++ b/docs/src/pages/docs/swift.mdx
@@ -157,7 +157,7 @@ Computes the layout of a node tree given a size. The size passed in is used to c
 <Code lang="swift">{`func computeLayout(thatFits size: Size<Float?>) -> Layout`}</Code>
 
 # Style
-The `Style` object contains all the properties associated with flexbox as well as some properties which we found useful outside of flexbox. For example `positionType` can be set to `PositionType.absolute` which puts the node into a absolute layout context instead of a flexbox context. `aspectRatio` is another property not part of the flexbox specification which when set ensures the node matches a certain aspect ratio.
+The `Style` object contains all the properties associated with flexbox as well as some properties which we found useful outside of flexbox. For example `positionType` can be set to `PositionType.absolute` which puts the node into an absolute layout context instead of a flexbox context. `aspectRatio` is another property not part of the flexbox specification which when set ensures the node matches a certain aspect ratio.
 
 <Code lang="swift">{`
 class Style {


### PR DESCRIPTION
Sorry to be that guy, but I found another typo. Figured might as well fix!