### PR TITLE
Add support for optional serialization/deserialization of Style with serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,11 @@ maintenance = { status = "experimental" }
 libm = "0.1.2"
 lazy_static = "1.3"
 
+[dependencies.serde]
+version = "1.0.99"
+features = ["serde_derive"]
+optional = true
+
 [features]
 default = ["std"]
 std = []

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -4,6 +4,9 @@ use crate::number::Number;
 use crate::style;
 
 #[derive(Debug, Copy, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(default))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub struct Rect<T> {
     pub start: T,
     pub end: T,
@@ -81,6 +84,9 @@ where
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(default))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub struct Size<T> {
     pub width: T,
     pub height: T,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,10 @@ extern crate alloc;
 #[macro_use]
 extern crate lazy_static;
 
+#[cfg_attr(feature = "serde", macro_use)]
+#[cfg(feature = "serde")]
+extern crate serde;
+
 pub mod geometry;
 pub mod node;
 pub mod number;

--- a/src/number.rs
+++ b/src/number.rs
@@ -1,6 +1,8 @@
 use core::ops;
 
 #[derive(Copy, Clone, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum Number {
     Defined(f32),
     Undefined,

--- a/src/style.rs
+++ b/src/style.rs
@@ -5,6 +5,8 @@ use crate::geometry::{Rect, Size};
 use crate::number::Number;
 
 #[derive(Copy, Clone, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum AlignItems {
     FlexStart,
     FlexEnd,
@@ -20,6 +22,8 @@ impl Default for AlignItems {
 }
 
 #[derive(Copy, Clone, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum AlignSelf {
     Auto,
     FlexStart,
@@ -36,6 +40,8 @@ impl Default for AlignSelf {
 }
 
 #[derive(Copy, Clone, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum AlignContent {
     FlexStart,
     FlexEnd,
@@ -52,9 +58,13 @@ impl Default for AlignContent {
 }
 
 #[derive(Copy, Clone, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum Direction {
     Inherit,
+    #[cfg_attr(feature = "serde", serde(rename = "ltr"))]
     LTR,
+    #[cfg_attr(feature = "serde", serde(rename = "rtl"))]
     RTL,
 }
 
@@ -65,8 +75,12 @@ impl Default for Direction {
 }
 
 #[derive(Copy, Clone, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum Display {
+    #[cfg_attr(feature = "serde", serde(rename = "flex"))]
     Flex,
+    #[cfg_attr(feature = "serde", serde(rename = "none"))]
     None,
 }
 
@@ -77,6 +91,8 @@ impl Default for Display {
 }
 
 #[derive(Copy, Clone, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum FlexDirection {
     Row,
     Column,
@@ -105,6 +121,8 @@ impl FlexDirection {
 }
 
 #[derive(Copy, Clone, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum JustifyContent {
     FlexStart,
     FlexEnd,
@@ -121,6 +139,8 @@ impl Default for JustifyContent {
 }
 
 #[derive(Copy, Clone, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum Overflow {
     Visible,
     Hidden,
@@ -134,6 +154,8 @@ impl Default for Overflow {
 }
 
 #[derive(Copy, Clone, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum PositionType {
     Relative,
     Absolute,
@@ -146,6 +168,8 @@ impl Default for PositionType {
 }
 
 #[derive(Copy, Clone, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum FlexWrap {
     NoWrap,
     Wrap,
@@ -159,6 +183,8 @@ impl Default for FlexWrap {
 }
 
 #[derive(Copy, Clone, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum Dimension {
     Undefined,
     Auto,
@@ -203,6 +229,9 @@ impl Default for Size<Dimension> {
 }
 
 #[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(default))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub struct Style {
     pub display: Display,
     pub position_type: PositionType,


### PR DESCRIPTION
This adds an optional `serde` feature, which when selected, enables serialization and deserialization of `Style` struct and other style related structs and enums.
To have a naming convention similar to CSS, I've used a "kebab-case" rule for renaming all the fields and variants names.
Here's a json serialized default Style:

```rust
println!("{}", serde_json::to_string_pretty(&Style {..Default::default()}).unwrap());
```

```json
{
  "display": "flex",
  "position-type": "relative",
  "direction": "inherit",
  "flex-direction": "row",
  "flex-wrap": "no-wrap",
  "overflow": "visible",
  "align-items": "stretch",
  "align-self": "auto",
  "align-content": "stretch",
  "justify-content": "flex-start",
  "position": {
    "start": "undefined",
    "end": "undefined",
    "top": "undefined",
    "bottom": "undefined"
  },
  "margin": {
    "start": "undefined",
    "end": "undefined",
    "top": "undefined",
    "bottom": "undefined"
  },
  "padding": {
    "start": "undefined",
    "end": "undefined",
    "top": "undefined",
    "bottom": "undefined"
  },
  "border": {
    "start": "undefined",
    "end": "undefined",
    "top": "undefined",
    "bottom": "undefined"
  },
  "flex-grow": 0.0,
  "flex-shrink": 1.0,
  "flex-basis": "auto",
  "size": {
    "width": "auto",
    "height": "auto"
  },
  "min-size": {
    "width": "auto",
    "height": "auto"
  },
  "max-size": {
    "width": "auto",
    "height": "auto"
  },
  "aspect-ratio": "undefined"
}
```

It also uses `Default` trait implemented in all structs and enums already, so by deserializing for example an empty object `{}` results in a default `Style`.