### PR TITLE
Support heapless environments (no_std without alloc)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,9 @@ jobs:
       - run: rustup component add rustfmt
       - run: rustup component add clippy
       - run: cargo fmt -- --check
-      - run: cargo test
+      - run: cargo test --no-default-features --features std
+      - run: cargo test --no-default-features --features alloc
+      - run: cargo test --no-default-features
       - run: cargo clippy
       - run: cargo bench
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ arrayvec = "0.5.1"
 hash32 = "0.1.1"
 hash32-derive = "0.1.0"
 heapless = "0.5.1"
-lazy_static = "1.4"
 typenum = "1.11.2"
 
 [dependencies.hashbrown]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,17 @@ circle-ci = { repository = "vislyhq/stretch", branch = "master" }
 maintenance = { status = "experimental" }
 
 [dependencies]
-hashbrown = "0.6.3"
+arrayvec = "0.5.1"
+hash32 = "0.1.1"
+hash32-derive = "0.1.0"
+heapless = "0.5.1"
 lazy_static = "1.4"
 spin = "0.5.2"
+typenum = "1.11.2"
+
+[dependencies.hashbrown]
+version = "0.6.3"
+optional = true
 
 [dependencies.serde]
 version = "1.0.102"
@@ -27,6 +35,7 @@ optional = true
 
 [features]
 default = ["std"]
+alloc = ["hashbrown"]
 std = []
 serde_camel_case = ["serde"]
 serde_kebab_case = ["serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ circle-ci = { repository = "vislyhq/stretch", branch = "master" }
 maintenance = { status = "experimental" }
 
 [dependencies]
-arrayvec = "0.5.1"
+arrayvec = { version = "0.5.1", default-features = false }
 hash32 = "0.1.1"
 hash32-derive = "0.1.0"
 heapless = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ hash32 = "0.1.1"
 hash32-derive = "0.1.0"
 heapless = "0.5.1"
 lazy_static = "1.4"
-spin = "0.5.2"
 typenum = "1.11.2"
 
 [dependencies.hashbrown]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ arrayvec = { version = "0.5.1", default-features = false }
 hash32 = "0.1.1"
 hash32-derive = "0.1.0"
 heapless = "0.5.1"
+num-traits = { version = "0.2.10", default-features = false }
 typenum = "1.11.2"
 
 [dependencies.hashbrown]
@@ -34,7 +35,7 @@ optional = true
 [features]
 default = ["std"]
 alloc = ["hashbrown"]
-std = []
+std = ["num-traits/std"]
 serde_camel_case = ["serde"]
 serde_kebab_case = ["serde"]
 

--- a/benches/complex.rs
+++ b/benches/complex.rs
@@ -10,7 +10,7 @@ fn build_deep_hierarchy(stretch: &mut stretch::node::Stretch) -> stretch::node::
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node112 = stretch
@@ -22,7 +22,7 @@ fn build_deep_hierarchy(stretch: &mut stretch::node::Stretch) -> stretch::node::
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
 
@@ -35,7 +35,7 @@ fn build_deep_hierarchy(stretch: &mut stretch::node::Stretch) -> stretch::node::
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node122 = stretch
@@ -47,13 +47,13 @@ fn build_deep_hierarchy(stretch: &mut stretch::node::Stretch) -> stretch::node::
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
 
-    let node11 = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node111, node112]).unwrap();
-    let node12 = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node121, node122]).unwrap();
-    let node1 = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node11, node12]).unwrap();
+    let node11 = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node111, node112]).unwrap();
+    let node12 = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node121, node122]).unwrap();
+    let node1 = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node11, node12]).unwrap();
 
     let node211 = stretch
         .new_node(
@@ -64,7 +64,7 @@ fn build_deep_hierarchy(stretch: &mut stretch::node::Stretch) -> stretch::node::
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node212 = stretch
@@ -76,7 +76,7 @@ fn build_deep_hierarchy(stretch: &mut stretch::node::Stretch) -> stretch::node::
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
 
@@ -89,7 +89,7 @@ fn build_deep_hierarchy(stretch: &mut stretch::node::Stretch) -> stretch::node::
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node222 = stretch
@@ -101,15 +101,15 @@ fn build_deep_hierarchy(stretch: &mut stretch::node::Stretch) -> stretch::node::
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
 
-    let node21 = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node211, node212]).unwrap();
-    let node22 = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node221, node222]).unwrap();
+    let node21 = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node211, node212]).unwrap();
+    let node22 = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node221, node222]).unwrap();
 
-    let node2 = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node21, node22]).unwrap();
-    let node0 = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node1, node2]).unwrap();
+    let node2 = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node21, node22]).unwrap();
+    let node0 = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node1, node2]).unwrap();
 
     node0
 }

--- a/benches/generated/absolute_layout_align_items_and_justify_content_center.rs
+++ b/benches/generated/absolute_layout_align_items_and_justify_content_center.rs
@@ -11,7 +11,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -26,7 +26,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/absolute_layout_align_items_and_justify_content_center_and_bottom_position.rs
+++ b/benches/generated/absolute_layout_align_items_and_justify_content_center_and_bottom_position.rs
@@ -15,7 +15,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -30,7 +30,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/absolute_layout_align_items_and_justify_content_center_and_left_position.rs
+++ b/benches/generated/absolute_layout_align_items_and_justify_content_center_and_left_position.rs
@@ -15,7 +15,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -30,7 +30,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/absolute_layout_align_items_and_justify_content_center_and_right_position.rs
+++ b/benches/generated/absolute_layout_align_items_and_justify_content_center_and_right_position.rs
@@ -15,7 +15,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -30,7 +30,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/absolute_layout_align_items_and_justify_content_center_and_top_position.rs
+++ b/benches/generated/absolute_layout_align_items_and_justify_content_center_and_top_position.rs
@@ -15,7 +15,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -30,7 +30,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/absolute_layout_align_items_and_justify_content_flex_end.rs
+++ b/benches/generated/absolute_layout_align_items_and_justify_content_flex_end.rs
@@ -11,7 +11,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -26,7 +26,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/absolute_layout_align_items_center.rs
+++ b/benches/generated/absolute_layout_align_items_center.rs
@@ -11,7 +11,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -25,7 +25,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/absolute_layout_align_items_center_on_child_only.rs
+++ b/benches/generated/absolute_layout_align_items_center_on_child_only.rs
@@ -12,7 +12,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -25,7 +25,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/absolute_layout_child_order.rs
+++ b/benches/generated/absolute_layout_child_order.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -24,7 +24,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -37,7 +37,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -52,7 +52,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/absolute_layout_in_wrap_reverse_column_container.rs
+++ b/benches/generated/absolute_layout_in_wrap_reverse_column_container.rs
@@ -11,7 +11,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -26,7 +26,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/absolute_layout_in_wrap_reverse_column_container_flex_end.rs
+++ b/benches/generated/absolute_layout_in_wrap_reverse_column_container_flex_end.rs
@@ -12,7 +12,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -27,7 +27,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/absolute_layout_in_wrap_reverse_row_container.rs
+++ b/benches/generated/absolute_layout_in_wrap_reverse_row_container.rs
@@ -11,7 +11,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -25,7 +25,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/absolute_layout_in_wrap_reverse_row_container_flex_end.rs
+++ b/benches/generated/absolute_layout_in_wrap_reverse_row_container_flex_end.rs
@@ -12,7 +12,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -26,7 +26,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/absolute_layout_justify_content_center.rs
+++ b/benches/generated/absolute_layout_justify_content_center.rs
@@ -11,7 +11,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -25,7 +25,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/absolute_layout_no_size.rs
+++ b/benches/generated/absolute_layout_no_size.rs
@@ -3,7 +3,7 @@ pub fn compute() {
     let node0 = stretch
         .new_node(
             stretch::style::Style { position_type: stretch::style::PositionType::Absolute, ..Default::default() },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -16,7 +16,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/absolute_layout_percentage_bottom_based_on_parent_height.rs
+++ b/benches/generated/absolute_layout_percentage_bottom_based_on_parent_height.rs
@@ -15,7 +15,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -33,7 +33,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -48,7 +48,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -61,7 +61,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/absolute_layout_start_top_end_bottom.rs
+++ b/benches/generated/absolute_layout_start_top_end_bottom.rs
@@ -13,7 +13,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -26,7 +26,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/absolute_layout_width_height_end_bottom.rs
+++ b/benches/generated/absolute_layout_width_height_end_bottom.rs
@@ -16,7 +16,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -29,7 +29,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/absolute_layout_width_height_start_top.rs
+++ b/benches/generated/absolute_layout_width_height_start_top.rs
@@ -16,7 +16,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -29,7 +29,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/absolute_layout_width_height_start_top_end_bottom.rs
+++ b/benches/generated/absolute_layout_width_height_start_top_end_bottom.rs
@@ -18,7 +18,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -31,7 +31,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/absolute_layout_within_border.rs
+++ b/benches/generated/absolute_layout_within_border.rs
@@ -16,7 +16,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -35,7 +35,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -61,7 +61,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node3 = stretch
@@ -87,7 +87,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -114,7 +114,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2, node3],
+            &[node0, node1, node2, node3],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/align_baseline.rs
+++ b/benches/generated/align_baseline.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -23,7 +23,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -37,7 +37,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/align_baseline_child_multiline.rs
+++ b/benches/generated/align_baseline_child_multiline.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node10 = stretch
@@ -23,7 +23,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node11 = stretch
@@ -36,7 +36,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node12 = stretch
@@ -49,7 +49,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node13 = stretch
@@ -62,7 +62,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -72,7 +72,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(50f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![node10, node11, node12, node13],
+            &[node10, node11, node12, node13],
         )
         .unwrap();
     let node = stretch
@@ -85,7 +85,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/align_baseline_nested_child.rs
+++ b/benches/generated/align_baseline_nested_child.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node10 = stretch
@@ -23,7 +23,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -37,7 +37,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node10],
+            &[node10],
         )
         .unwrap();
     let node = stretch
@@ -51,7 +51,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/align_center_should_size_based_on_content.rs
+++ b/benches/generated/align_center_should_size_based_on_content.rs
@@ -10,11 +10,11 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node00 = stretch
-        .new_node(stretch::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, vec![node000])
+        .new_node(stretch::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[node000])
         .unwrap();
     let node0 = stretch
         .new_node(
@@ -24,7 +24,7 @@ pub fn compute() {
                 flex_shrink: 1f32,
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node = stretch
@@ -38,7 +38,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/align_flex_start_with_shrinking_children.rs
+++ b/benches/generated/align_flex_start_with_shrinking_children.rs
@@ -1,15 +1,15 @@
 pub fn compute() {
     let mut stretch = stretch::Stretch::new();
     let node000 = stretch
-        .new_node(stretch::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, vec![])
+        .new_node(stretch::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[])
         .unwrap();
     let node00 = stretch
-        .new_node(stretch::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, vec![node000])
+        .new_node(stretch::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[node000])
         .unwrap();
     let node0 = stretch
         .new_node(
             stretch::style::Style { align_items: stretch::style::AlignItems::FlexStart, ..Default::default() },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node = stretch
@@ -22,7 +22,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/align_flex_start_with_shrinking_children_with_stretch.rs
+++ b/benches/generated/align_flex_start_with_shrinking_children_with_stretch.rs
@@ -1,15 +1,15 @@
 pub fn compute() {
     let mut stretch = stretch::Stretch::new();
     let node000 = stretch
-        .new_node(stretch::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, vec![])
+        .new_node(stretch::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[])
         .unwrap();
     let node00 = stretch
-        .new_node(stretch::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, vec![node000])
+        .new_node(stretch::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[node000])
         .unwrap();
     let node0 = stretch
         .new_node(
             stretch::style::Style { align_items: stretch::style::AlignItems::FlexStart, ..Default::default() },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node = stretch
@@ -22,7 +22,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/align_flex_start_with_stretching_children.rs
+++ b/benches/generated/align_flex_start_with_stretching_children.rs
@@ -1,12 +1,12 @@
 pub fn compute() {
     let mut stretch = stretch::Stretch::new();
     let node000 = stretch
-        .new_node(stretch::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, vec![])
+        .new_node(stretch::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[])
         .unwrap();
     let node00 = stretch
-        .new_node(stretch::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, vec![node000])
+        .new_node(stretch::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[node000])
         .unwrap();
-    let node0 = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node00]).unwrap();
+    let node0 = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node00]).unwrap();
     let node = stretch
         .new_node(
             stretch::style::Style {
@@ -17,7 +17,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/align_items_center.rs
+++ b/benches/generated/align_items_center.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -24,7 +24,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/align_items_center_child_with_margin_bigger_than_parent.rs
+++ b/benches/generated/align_items_center_child_with_margin_bigger_than_parent.rs
@@ -15,13 +15,13 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
         .new_node(
             stretch::style::Style { align_items: stretch::style::AlignItems::Center, ..Default::default() },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node = stretch
@@ -36,7 +36,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/align_items_center_child_without_margin_bigger_than_parent.rs
+++ b/benches/generated/align_items_center_child_without_margin_bigger_than_parent.rs
@@ -10,13 +10,13 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
         .new_node(
             stretch::style::Style { align_items: stretch::style::AlignItems::Center, ..Default::default() },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node = stretch
@@ -31,7 +31,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/align_items_center_with_child_margin.rs
+++ b/benches/generated/align_items_center_with_child_margin.rs
@@ -11,7 +11,7 @@ pub fn compute() {
                 margin: stretch::geometry::Rect { top: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -25,7 +25,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/align_items_center_with_child_top.rs
+++ b/benches/generated/align_items_center_with_child_top.rs
@@ -14,7 +14,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -28,7 +28,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/align_items_flex_end.rs
+++ b/benches/generated/align_items_flex_end.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -24,7 +24,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/align_items_flex_end_child_with_margin_bigger_than_parent.rs
+++ b/benches/generated/align_items_flex_end_child_with_margin_bigger_than_parent.rs
@@ -15,13 +15,13 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
         .new_node(
             stretch::style::Style { align_items: stretch::style::AlignItems::FlexEnd, ..Default::default() },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node = stretch
@@ -36,7 +36,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/align_items_flex_end_child_without_margin_bigger_than_parent.rs
+++ b/benches/generated/align_items_flex_end_child_without_margin_bigger_than_parent.rs
@@ -10,13 +10,13 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
         .new_node(
             stretch::style::Style { align_items: stretch::style::AlignItems::FlexEnd, ..Default::default() },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node = stretch
@@ -31,7 +31,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/align_items_flex_start.rs
+++ b/benches/generated/align_items_flex_start.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -24,7 +24,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/align_items_min_max.rs
+++ b/benches/generated/align_items_min_max.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -32,7 +32,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/align_items_stretch.rs
+++ b/benches/generated/align_items_stretch.rs
@@ -6,7 +6,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -19,7 +19,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/align_self_baseline.rs
+++ b/benches/generated/align_self_baseline.rs
@@ -11,7 +11,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node10 = stretch
@@ -24,7 +24,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -38,7 +38,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node10],
+            &[node10],
         )
         .unwrap();
     let node = stretch
@@ -51,7 +51,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/align_self_center.rs
+++ b/benches/generated/align_self_center.rs
@@ -11,7 +11,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -24,7 +24,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/align_self_flex_end.rs
+++ b/benches/generated/align_self_flex_end.rs
@@ -11,7 +11,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -24,7 +24,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/align_self_flex_end_override_flex_start.rs
+++ b/benches/generated/align_self_flex_end_override_flex_start.rs
@@ -11,7 +11,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -25,7 +25,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/align_self_flex_start.rs
+++ b/benches/generated/align_self_flex_start.rs
@@ -11,7 +11,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -24,7 +24,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/align_strech_should_size_based_on_parent.rs
+++ b/benches/generated/align_strech_should_size_based_on_parent.rs
@@ -10,11 +10,11 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node00 = stretch
-        .new_node(stretch::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, vec![node000])
+        .new_node(stretch::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[node000])
         .unwrap();
     let node0 = stretch
         .new_node(
@@ -24,7 +24,7 @@ pub fn compute() {
                 flex_shrink: 1f32,
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node = stretch
@@ -37,7 +37,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/border_center_child.rs
+++ b/benches/generated/border_center_child.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -30,7 +30,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/border_flex_child.rs
+++ b/benches/generated/border_flex_child.rs
@@ -7,7 +7,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -27,7 +27,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/border_no_child.rs
+++ b/benches/generated/border_no_child.rs
@@ -12,7 +12,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/border_stretch_child.rs
+++ b/benches/generated/border_stretch_child.rs
@@ -6,7 +6,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -26,7 +26,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/child_min_max_width_flexing.rs
+++ b/benches/generated/child_min_max_width_flexing.rs
@@ -12,7 +12,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -27,7 +27,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -40,7 +40,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/container_with_unsized_child.rs
+++ b/benches/generated/container_with_unsized_child.rs
@@ -1,6 +1,6 @@
 pub fn compute() {
     let mut stretch = stretch::Stretch::new();
-    let node0 = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![]).unwrap();
+    let node0 = stretch.new_node(stretch::style::Style { ..Default::default() }, &[]).unwrap();
     let node = stretch
         .new_node(
             stretch::style::Style {
@@ -11,7 +11,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/display_none.rs
+++ b/benches/generated/display_none.rs
@@ -1,10 +1,10 @@
 pub fn compute() {
     let mut stretch = stretch::Stretch::new();
-    let node0 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
+    let node0 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node1 = stretch
         .new_node(
             stretch::style::Style { display: stretch::style::Display::None, flex_grow: 1f32, ..Default::default() },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -17,7 +17,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/display_none_fixed_size.rs
+++ b/benches/generated/display_none_fixed_size.rs
@@ -1,6 +1,6 @@
 pub fn compute() {
     let mut stretch = stretch::Stretch::new();
-    let node0 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
+    let node0 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node1 = stretch
         .new_node(
             stretch::style::Style {
@@ -12,7 +12,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -25,7 +25,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/display_none_with_child.rs
+++ b/benches/generated/display_none_with_child.rs
@@ -8,7 +8,7 @@ pub fn compute() {
                 flex_basis: stretch::style::Dimension::Percent(0f32),
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node10 = stretch
@@ -20,7 +20,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(20f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -33,7 +33,7 @@ pub fn compute() {
                 flex_basis: stretch::style::Dimension::Percent(0f32),
                 ..Default::default()
             },
-            vec![node10],
+            &[node10],
         )
         .unwrap();
     let node2 = stretch
@@ -44,7 +44,7 @@ pub fn compute() {
                 flex_basis: stretch::style::Dimension::Percent(0f32),
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -57,7 +57,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/display_none_with_margin.rs
+++ b/benches/generated/display_none_with_margin.rs
@@ -18,10 +18,10 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
-    let node1 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
+    let node1 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node = stretch
         .new_node(
             stretch::style::Style {
@@ -32,7 +32,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/display_none_with_position.rs
+++ b/benches/generated/display_none_with_position.rs
@@ -1,6 +1,6 @@
 pub fn compute() {
     let mut stretch = stretch::Stretch::new();
-    let node0 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
+    let node0 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node1 = stretch
         .new_node(
             stretch::style::Style {
@@ -12,7 +12,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -25,7 +25,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_basis_and_main_dimen_set_when_flexing.rs
+++ b/benches/generated/flex_basis_and_main_dimen_set_when_flexing.rs
@@ -12,7 +12,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -27,7 +27,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -39,7 +39,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_basis_flex_grow_column.rs
+++ b/benches/generated/flex_basis_flex_grow_column.rs
@@ -7,10 +7,10 @@ pub fn compute() {
                 flex_basis: stretch::style::Dimension::Points(50f32),
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
-    let node1 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
+    let node1 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node = stretch
         .new_node(
             stretch::style::Style {
@@ -22,7 +22,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_basis_flex_grow_row.rs
+++ b/benches/generated/flex_basis_flex_grow_row.rs
@@ -7,10 +7,10 @@ pub fn compute() {
                 flex_basis: stretch::style::Dimension::Points(50f32),
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
-    let node1 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
+    let node1 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node = stretch
         .new_node(
             stretch::style::Style {
@@ -21,7 +21,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_basis_flex_shrink_column.rs
+++ b/benches/generated/flex_basis_flex_shrink_column.rs
@@ -3,13 +3,13 @@ pub fn compute() {
     let node0 = stretch
         .new_node(
             stretch::style::Style { flex_basis: stretch::style::Dimension::Points(100f32), ..Default::default() },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
         .new_node(
             stretch::style::Style { flex_basis: stretch::style::Dimension::Points(50f32), ..Default::default() },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -23,7 +23,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_basis_flex_shrink_row.rs
+++ b/benches/generated/flex_basis_flex_shrink_row.rs
@@ -3,13 +3,13 @@ pub fn compute() {
     let node0 = stretch
         .new_node(
             stretch::style::Style { flex_basis: stretch::style::Dimension::Points(100f32), ..Default::default() },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
         .new_node(
             stretch::style::Style { flex_basis: stretch::style::Dimension::Points(50f32), ..Default::default() },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -22,7 +22,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_basis_larger_than_content_column.rs
+++ b/benches/generated/flex_basis_larger_than_content_column.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -20,7 +20,7 @@ pub fn compute() {
                 flex_basis: stretch::style::Dimension::Points(50f32),
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node = stretch
@@ -33,7 +33,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_basis_larger_than_content_row.rs
+++ b/benches/generated/flex_basis_larger_than_content_row.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -20,7 +20,7 @@ pub fn compute() {
                 flex_basis: stretch::style::Dimension::Points(50f32),
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node = stretch
@@ -32,7 +32,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_basis_overrides_main_size.rs
+++ b/benches/generated/flex_basis_overrides_main_size.rs
@@ -8,7 +8,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(20f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -18,7 +18,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -28,7 +28,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -41,7 +41,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_basis_slightly_smaller_then_content_with_flex_grow_large_size.rs
+++ b/benches/generated/flex_basis_slightly_smaller_then_content_with_flex_grow_large_size.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -21,7 +21,7 @@ pub fn compute() {
                 flex_basis: stretch::style::Dimension::Points(60f32),
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node10 = stretch
@@ -34,7 +34,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -45,7 +45,7 @@ pub fn compute() {
                 flex_basis: stretch::style::Dimension::Points(0f32),
                 ..Default::default()
             },
-            vec![node10],
+            &[node10],
         )
         .unwrap();
     let node = stretch
@@ -57,7 +57,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_basis_smaller_than_content_column.rs
+++ b/benches/generated/flex_basis_smaller_than_content_column.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -20,7 +20,7 @@ pub fn compute() {
                 flex_basis: stretch::style::Dimension::Points(50f32),
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node = stretch
@@ -33,7 +33,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_basis_smaller_than_content_row.rs
+++ b/benches/generated/flex_basis_smaller_than_content_row.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -20,7 +20,7 @@ pub fn compute() {
                 flex_basis: stretch::style::Dimension::Points(50f32),
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node = stretch
@@ -32,7 +32,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_basis_smaller_than_main_dimen_column.rs
+++ b/benches/generated/flex_basis_smaller_than_main_dimen_column.rs
@@ -11,7 +11,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -24,7 +24,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_basis_smaller_than_main_dimen_row.rs
+++ b/benches/generated/flex_basis_smaller_than_main_dimen_row.rs
@@ -11,7 +11,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -23,7 +23,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_basis_smaller_then_content_with_flex_grow_large_size.rs
+++ b/benches/generated/flex_basis_smaller_then_content_with_flex_grow_large_size.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -21,7 +21,7 @@ pub fn compute() {
                 flex_basis: stretch::style::Dimension::Points(0f32),
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node10 = stretch
@@ -34,7 +34,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -45,7 +45,7 @@ pub fn compute() {
                 flex_basis: stretch::style::Dimension::Points(0f32),
                 ..Default::default()
             },
-            vec![node10],
+            &[node10],
         )
         .unwrap();
     let node = stretch
@@ -57,7 +57,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_basis_smaller_then_content_with_flex_grow_small_size.rs
+++ b/benches/generated/flex_basis_smaller_then_content_with_flex_grow_small_size.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -21,7 +21,7 @@ pub fn compute() {
                 flex_basis: stretch::style::Dimension::Points(0f32),
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node10 = stretch
@@ -34,7 +34,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -45,7 +45,7 @@ pub fn compute() {
                 flex_basis: stretch::style::Dimension::Points(0f32),
                 ..Default::default()
             },
-            vec![node10],
+            &[node10],
         )
         .unwrap();
     let node = stretch
@@ -54,7 +54,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_basis_smaller_then_content_with_flex_grow_unconstraint_size.rs
+++ b/benches/generated/flex_basis_smaller_then_content_with_flex_grow_unconstraint_size.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -21,7 +21,7 @@ pub fn compute() {
                 flex_basis: stretch::style::Dimension::Points(0f32),
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node10 = stretch
@@ -34,7 +34,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -45,9 +45,9 @@ pub fn compute() {
                 flex_basis: stretch::style::Dimension::Points(0f32),
                 ..Default::default()
             },
-            vec![node10],
+            &[node10],
         )
         .unwrap();
-    let node = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node0, node1]).unwrap();
+    let node = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node0, node1]).unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_basis_smaller_then_content_with_flex_grow_very_large_size.rs
+++ b/benches/generated/flex_basis_smaller_then_content_with_flex_grow_very_large_size.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -21,7 +21,7 @@ pub fn compute() {
                 flex_basis: stretch::style::Dimension::Points(0f32),
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node10 = stretch
@@ -34,7 +34,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -45,7 +45,7 @@ pub fn compute() {
                 flex_basis: stretch::style::Dimension::Points(0f32),
                 ..Default::default()
             },
-            vec![node10],
+            &[node10],
         )
         .unwrap();
     let node = stretch
@@ -57,7 +57,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_basis_unconstraint_column.rs
+++ b/benches/generated/flex_basis_unconstraint_column.rs
@@ -10,13 +10,13 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
         .new_node(
             stretch::style::Style { flex_direction: stretch::style::FlexDirection::Column, ..Default::default() },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_basis_unconstraint_row.rs
+++ b/benches/generated/flex_basis_unconstraint_row.rs
@@ -10,9 +10,9 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
-    let node = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node0]).unwrap();
+    let node = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node0]).unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_direction_column.rs
+++ b/benches/generated/flex_direction_column.rs
@@ -9,7 +9,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -21,7 +21,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -33,7 +33,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -47,7 +47,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_direction_column_no_height.rs
+++ b/benches/generated/flex_direction_column_no_height.rs
@@ -9,7 +9,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -21,7 +21,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -33,7 +33,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -46,7 +46,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_direction_column_reverse.rs
+++ b/benches/generated/flex_direction_column_reverse.rs
@@ -9,7 +9,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -21,7 +21,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -33,7 +33,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -47,7 +47,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_direction_row.rs
+++ b/benches/generated/flex_direction_row.rs
@@ -6,7 +6,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -15,7 +15,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -24,7 +24,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -37,7 +37,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_direction_row_no_width.rs
+++ b/benches/generated/flex_direction_row_no_width.rs
@@ -6,7 +6,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -15,7 +15,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -24,7 +24,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -36,7 +36,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_direction_row_reverse.rs
+++ b/benches/generated/flex_direction_row_reverse.rs
@@ -6,7 +6,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -15,7 +15,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -24,7 +24,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -38,7 +38,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_grow_child.rs
+++ b/benches/generated/flex_grow_child.rs
@@ -11,9 +11,9 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
-    let node = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node0]).unwrap();
+    let node = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node0]).unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_grow_flex_basis_percent_min_max.rs
+++ b/benches/generated/flex_grow_flex_basis_percent_min_max.rs
@@ -16,7 +16,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -36,7 +36,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -48,7 +48,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_grow_height_maximized.rs
+++ b/benches/generated/flex_grow_height_maximized.rs
@@ -7,7 +7,7 @@ pub fn compute() {
                 flex_basis: stretch::style::Dimension::Points(200f32),
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node01 = stretch
@@ -19,7 +19,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -37,7 +37,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node00, node01],
+            &[node00, node01],
         )
         .unwrap();
     let node = stretch
@@ -51,7 +51,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_grow_in_at_most_container.rs
+++ b/benches/generated/flex_grow_in_at_most_container.rs
@@ -7,10 +7,10 @@ pub fn compute() {
                 flex_basis: stretch::style::Dimension::Points(0f32),
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
-    let node0 = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node00]).unwrap();
+    let node0 = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node00]).unwrap();
     let node = stretch
         .new_node(
             stretch::style::Style {
@@ -22,7 +22,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_grow_less_than_factor_one.rs
+++ b/benches/generated/flex_grow_less_than_factor_one.rs
@@ -8,14 +8,14 @@ pub fn compute() {
                 flex_basis: stretch::style::Dimension::Points(40f32),
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
-        .new_node(stretch::style::Style { flex_grow: 0.2f32, flex_shrink: 0f32, ..Default::default() }, vec![])
+        .new_node(stretch::style::Style { flex_grow: 0.2f32, flex_shrink: 0f32, ..Default::default() }, &[])
         .unwrap();
     let node2 = stretch
-        .new_node(stretch::style::Style { flex_grow: 0.4f32, flex_shrink: 0f32, ..Default::default() }, vec![])
+        .new_node(stretch::style::Style { flex_grow: 0.4f32, flex_shrink: 0f32, ..Default::default() }, &[])
         .unwrap();
     let node = stretch
         .new_node(
@@ -27,7 +27,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_grow_root_minimized.rs
+++ b/benches/generated/flex_grow_root_minimized.rs
@@ -7,7 +7,7 @@ pub fn compute() {
                 flex_basis: stretch::style::Dimension::Points(200f32),
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node01 = stretch
@@ -19,7 +19,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -37,7 +37,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node00, node01],
+            &[node00, node01],
         )
         .unwrap();
     let node = stretch
@@ -58,7 +58,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_grow_shrink_at_most.rs
+++ b/benches/generated/flex_grow_shrink_at_most.rs
@@ -1,9 +1,9 @@
 pub fn compute() {
     let mut stretch = stretch::Stretch::new();
     let node00 = stretch
-        .new_node(stretch::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, vec![])
+        .new_node(stretch::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[])
         .unwrap();
-    let node0 = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node00]).unwrap();
+    let node0 = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node00]).unwrap();
     let node = stretch
         .new_node(
             stretch::style::Style {
@@ -14,7 +14,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_grow_to_min.rs
+++ b/benches/generated/flex_grow_to_min.rs
@@ -1,7 +1,7 @@
 pub fn compute() {
     let mut stretch = stretch::Stretch::new();
     let node0 = stretch
-        .new_node(stretch::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, vec![])
+        .new_node(stretch::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[])
         .unwrap();
     let node1 = stretch
         .new_node(
@@ -12,7 +12,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -33,7 +33,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_grow_within_constrained_max_column.rs
+++ b/benches/generated/flex_grow_within_constrained_max_column.rs
@@ -7,7 +7,7 @@ pub fn compute() {
                 flex_basis: stretch::style::Dimension::Points(100f32),
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -19,7 +19,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -36,7 +36,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_grow_within_constrained_max_row.rs
+++ b/benches/generated/flex_grow_within_constrained_max_row.rs
@@ -7,7 +7,7 @@ pub fn compute() {
                 flex_basis: stretch::style::Dimension::Points(100f32),
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node01 = stretch
@@ -16,7 +16,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(50f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -32,7 +32,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node00, node01],
+            &[node00, node01],
         )
         .unwrap();
     let node = stretch
@@ -45,7 +45,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_grow_within_constrained_max_width.rs
+++ b/benches/generated/flex_grow_within_constrained_max_width.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -22,7 +22,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node = stretch
@@ -36,7 +36,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_grow_within_constrained_min_column.rs
+++ b/benches/generated/flex_grow_within_constrained_min_column.rs
@@ -1,6 +1,6 @@
 pub fn compute() {
     let mut stretch = stretch::Stretch::new();
-    let node0 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
+    let node0 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node1 = stretch
         .new_node(
             stretch::style::Style {
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -23,7 +23,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_grow_within_constrained_min_max_column.rs
+++ b/benches/generated/flex_grow_within_constrained_min_max_column.rs
@@ -1,6 +1,6 @@
 pub fn compute() {
     let mut stretch = stretch::Stretch::new();
-    let node0 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
+    let node0 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node1 = stretch
         .new_node(
             stretch::style::Style {
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -22,7 +22,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_grow_within_constrained_min_row.rs
+++ b/benches/generated/flex_grow_within_constrained_min_row.rs
@@ -1,13 +1,13 @@
 pub fn compute() {
     let mut stretch = stretch::Stretch::new();
-    let node0 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
+    let node0 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node1 = stretch
         .new_node(
             stretch::style::Style {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(50f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -23,7 +23,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_grow_within_max_width.rs
+++ b/benches/generated/flex_grow_within_max_width.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -22,7 +22,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node = stretch
@@ -36,7 +36,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_root_ignored.rs
+++ b/benches/generated/flex_root_ignored.rs
@@ -7,7 +7,7 @@ pub fn compute() {
                 flex_basis: stretch::style::Dimension::Points(200f32),
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -19,7 +19,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -40,7 +40,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_shrink_by_outer_margin_with_max_size.rs
+++ b/benches/generated/flex_shrink_by_outer_margin_with_max_size.rs
@@ -14,7 +14,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -31,7 +31,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_shrink_flex_grow_child_flex_shrink_other_child.rs
+++ b/benches/generated/flex_shrink_flex_grow_child_flex_shrink_other_child.rs
@@ -12,7 +12,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -27,7 +27,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -40,7 +40,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_shrink_flex_grow_row.rs
+++ b/benches/generated/flex_shrink_flex_grow_row.rs
@@ -12,7 +12,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -27,7 +27,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -40,7 +40,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_shrink_to_zero.rs
+++ b/benches/generated/flex_shrink_to_zero.rs
@@ -11,7 +11,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -25,7 +25,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -39,7 +39,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -48,7 +48,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(75f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_wrap_align_stretch_fits_one_row.rs
+++ b/benches/generated/flex_wrap_align_stretch_fits_one_row.rs
@@ -6,7 +6,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(50f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -15,7 +15,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(50f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -29,7 +29,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_wrap_children_with_min_main_overriding_flex_basis.rs
+++ b/benches/generated/flex_wrap_children_with_min_main_overriding_flex_basis.rs
@@ -14,7 +14,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -31,7 +31,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -44,7 +44,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/flex_wrap_wrap_to_child_height.rs
+++ b/benches/generated/flex_wrap_wrap_to_child_height.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node00 = stretch
@@ -23,7 +23,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node000],
+            &[node000],
         )
         .unwrap();
     let node0 = stretch
@@ -33,7 +33,7 @@ pub fn compute() {
                 align_items: stretch::style::AlignItems::FlexStart,
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node1 = stretch
@@ -46,13 +46,13 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
         .new_node(
             stretch::style::Style { flex_direction: stretch::style::FlexDirection::Column, ..Default::default() },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/justify_content_column_center.rs
+++ b/benches/generated/justify_content_column_center.rs
@@ -9,7 +9,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -21,7 +21,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -33,7 +33,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -48,7 +48,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/justify_content_column_flex_end.rs
+++ b/benches/generated/justify_content_column_flex_end.rs
@@ -9,7 +9,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -21,7 +21,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -33,7 +33,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -48,7 +48,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/justify_content_column_flex_start.rs
+++ b/benches/generated/justify_content_column_flex_start.rs
@@ -9,7 +9,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -21,7 +21,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -33,7 +33,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -47,7 +47,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/justify_content_column_min_height_and_margin_bottom.rs
+++ b/benches/generated/justify_content_column_min_height_and_margin_bottom.rs
@@ -14,7 +14,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -28,7 +28,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/justify_content_column_min_height_and_margin_top.rs
+++ b/benches/generated/justify_content_column_min_height_and_margin_top.rs
@@ -11,7 +11,7 @@ pub fn compute() {
                 margin: stretch::geometry::Rect { top: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -25,7 +25,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/justify_content_column_space_around.rs
+++ b/benches/generated/justify_content_column_space_around.rs
@@ -9,7 +9,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -21,7 +21,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -33,7 +33,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -48,7 +48,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/justify_content_column_space_between.rs
+++ b/benches/generated/justify_content_column_space_between.rs
@@ -9,7 +9,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -21,7 +21,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -33,7 +33,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -48,7 +48,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/justify_content_column_space_evenly.rs
+++ b/benches/generated/justify_content_column_space_evenly.rs
@@ -9,7 +9,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -21,7 +21,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -33,7 +33,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -48,7 +48,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/justify_content_min_max.rs
+++ b/benches/generated/justify_content_min_max.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -32,7 +32,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/justify_content_min_width_with_padding_child_width_greater_than_parent.rs
+++ b/benches/generated/justify_content_min_width_with_padding_child_width_greater_than_parent.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node00 = stretch
@@ -28,10 +28,10 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node000],
+            &[node000],
         )
         .unwrap();
-    let node0 = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node00]).unwrap();
+    let node0 = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node00]).unwrap();
     let node = stretch
         .new_node(
             stretch::style::Style {
@@ -43,7 +43,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/justify_content_min_width_with_padding_child_width_lower_than_parent.rs
+++ b/benches/generated/justify_content_min_width_with_padding_child_width_lower_than_parent.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node00 = stretch
@@ -28,10 +28,10 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node000],
+            &[node000],
         )
         .unwrap();
-    let node0 = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node00]).unwrap();
+    let node0 = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node00]).unwrap();
     let node = stretch
         .new_node(
             stretch::style::Style {
@@ -43,7 +43,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/justify_content_overflow_min_max.rs
+++ b/benches/generated/justify_content_overflow_min_max.rs
@@ -11,7 +11,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -25,7 +25,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -39,7 +39,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -57,7 +57,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/justify_content_row_center.rs
+++ b/benches/generated/justify_content_row_center.rs
@@ -6,7 +6,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -15,7 +15,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -24,7 +24,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -38,7 +38,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/justify_content_row_flex_end.rs
+++ b/benches/generated/justify_content_row_flex_end.rs
@@ -6,7 +6,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -15,7 +15,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -24,7 +24,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -38,7 +38,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/justify_content_row_flex_start.rs
+++ b/benches/generated/justify_content_row_flex_start.rs
@@ -6,7 +6,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -15,7 +15,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -24,7 +24,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -37,7 +37,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/justify_content_row_max_width_and_margin.rs
+++ b/benches/generated/justify_content_row_max_width_and_margin.rs
@@ -14,7 +14,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -31,7 +31,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/justify_content_row_min_width_and_margin.rs
+++ b/benches/generated/justify_content_row_min_width_and_margin.rs
@@ -14,7 +14,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -27,7 +27,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/justify_content_row_space_around.rs
+++ b/benches/generated/justify_content_row_space_around.rs
@@ -6,7 +6,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -15,7 +15,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -24,7 +24,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -38,7 +38,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/justify_content_row_space_between.rs
+++ b/benches/generated/justify_content_row_space_between.rs
@@ -6,7 +6,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -15,7 +15,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -24,7 +24,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -38,7 +38,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/justify_content_row_space_evenly.rs
+++ b/benches/generated/justify_content_row_space_evenly.rs
@@ -9,7 +9,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -21,7 +21,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -33,7 +33,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -47,7 +47,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/margin_and_flex_column.rs
+++ b/benches/generated/margin_and_flex_column.rs
@@ -11,7 +11,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -25,7 +25,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/margin_and_flex_row.rs
+++ b/benches/generated/margin_and_flex_row.rs
@@ -11,7 +11,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -24,7 +24,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/margin_and_stretch_column.rs
+++ b/benches/generated/margin_and_stretch_column.rs
@@ -11,7 +11,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -25,7 +25,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/margin_and_stretch_row.rs
+++ b/benches/generated/margin_and_stretch_row.rs
@@ -11,7 +11,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -24,7 +24,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/margin_auto_bottom.rs
+++ b/benches/generated/margin_auto_bottom.rs
@@ -11,7 +11,7 @@ pub fn compute() {
                 margin: stretch::geometry::Rect { bottom: stretch::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -24,7 +24,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -38,7 +38,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/margin_auto_bottom_and_top.rs
+++ b/benches/generated/margin_auto_bottom_and_top.rs
@@ -15,7 +15,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -28,7 +28,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -42,7 +42,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/margin_auto_bottom_and_top_justify_center.rs
+++ b/benches/generated/margin_auto_bottom_and_top_justify_center.rs
@@ -15,7 +15,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -28,7 +28,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -42,7 +42,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/margin_auto_left.rs
+++ b/benches/generated/margin_auto_left.rs
@@ -11,7 +11,7 @@ pub fn compute() {
                 margin: stretch::geometry::Rect { start: stretch::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -24,7 +24,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -38,7 +38,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/margin_auto_left_and_right.rs
+++ b/benches/generated/margin_auto_left_and_right.rs
@@ -15,7 +15,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -28,7 +28,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -41,7 +41,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/margin_auto_left_and_right_column.rs
+++ b/benches/generated/margin_auto_left_and_right_column.rs
@@ -15,7 +15,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -28,7 +28,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -42,7 +42,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/margin_auto_left_and_right_column_and_center.rs
+++ b/benches/generated/margin_auto_left_and_right_column_and_center.rs
@@ -15,7 +15,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -28,7 +28,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -42,7 +42,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/margin_auto_left_and_right_strech.rs
+++ b/benches/generated/margin_auto_left_and_right_strech.rs
@@ -15,7 +15,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -28,7 +28,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -41,7 +41,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/margin_auto_left_child_bigger_than_parent.rs
+++ b/benches/generated/margin_auto_left_child_bigger_than_parent.rs
@@ -11,7 +11,7 @@ pub fn compute() {
                 margin: stretch::geometry::Rect { start: stretch::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -25,7 +25,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/margin_auto_left_fix_right_child_bigger_than_parent.rs
+++ b/benches/generated/margin_auto_left_fix_right_child_bigger_than_parent.rs
@@ -15,7 +15,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -29,7 +29,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/margin_auto_left_right_child_bigger_than_parent.rs
+++ b/benches/generated/margin_auto_left_right_child_bigger_than_parent.rs
@@ -15,7 +15,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -29,7 +29,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/margin_auto_left_stretching_child.rs
+++ b/benches/generated/margin_auto_left_stretching_child.rs
@@ -9,7 +9,7 @@ pub fn compute() {
                 margin: stretch::geometry::Rect { start: stretch::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -22,7 +22,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -36,7 +36,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/margin_auto_mutiple_children_column.rs
+++ b/benches/generated/margin_auto_mutiple_children_column.rs
@@ -11,7 +11,7 @@ pub fn compute() {
                 margin: stretch::geometry::Rect { top: stretch::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -25,7 +25,7 @@ pub fn compute() {
                 margin: stretch::geometry::Rect { top: stretch::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -38,7 +38,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -53,7 +53,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/margin_auto_mutiple_children_row.rs
+++ b/benches/generated/margin_auto_mutiple_children_row.rs
@@ -11,7 +11,7 @@ pub fn compute() {
                 margin: stretch::geometry::Rect { end: stretch::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -25,7 +25,7 @@ pub fn compute() {
                 margin: stretch::geometry::Rect { end: stretch::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -38,7 +38,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -52,7 +52,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/margin_auto_right.rs
+++ b/benches/generated/margin_auto_right.rs
@@ -11,7 +11,7 @@ pub fn compute() {
                 margin: stretch::geometry::Rect { end: stretch::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -24,7 +24,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -38,7 +38,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/margin_auto_top.rs
+++ b/benches/generated/margin_auto_top.rs
@@ -11,7 +11,7 @@ pub fn compute() {
                 margin: stretch::geometry::Rect { top: stretch::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -24,7 +24,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -38,7 +38,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/margin_auto_top_and_bottom_strech.rs
+++ b/benches/generated/margin_auto_top_and_bottom_strech.rs
@@ -15,7 +15,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -28,7 +28,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -42,7 +42,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/margin_auto_top_stretching_child.rs
+++ b/benches/generated/margin_auto_top_stretching_child.rs
@@ -9,7 +9,7 @@ pub fn compute() {
                 margin: stretch::geometry::Rect { top: stretch::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -22,7 +22,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -36,7 +36,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/margin_bottom.rs
+++ b/benches/generated/margin_bottom.rs
@@ -13,7 +13,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -28,7 +28,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/margin_fix_left_auto_right_child_bigger_than_parent.rs
+++ b/benches/generated/margin_fix_left_auto_right_child_bigger_than_parent.rs
@@ -15,7 +15,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -29,7 +29,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/margin_left.rs
+++ b/benches/generated/margin_left.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -23,7 +23,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/margin_right.rs
+++ b/benches/generated/margin_right.rs
@@ -7,7 +7,7 @@ pub fn compute() {
                 margin: stretch::geometry::Rect { end: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -21,7 +21,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/margin_should_not_be_part_of_max_height.rs
+++ b/benches/generated/margin_should_not_be_part_of_max_height.rs
@@ -15,7 +15,7 @@ pub fn compute() {
                 margin: stretch::geometry::Rect { top: stretch::style::Dimension::Points(20f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -28,7 +28,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/margin_should_not_be_part_of_max_width.rs
+++ b/benches/generated/margin_should_not_be_part_of_max_width.rs
@@ -18,7 +18,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -31,7 +31,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/margin_top.rs
+++ b/benches/generated/margin_top.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 margin: stretch::geometry::Rect { top: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -24,7 +24,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/margin_with_sibling_column.rs
+++ b/benches/generated/margin_with_sibling_column.rs
@@ -10,10 +10,10 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
-    let node1 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
+    let node1 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node = stretch
         .new_node(
             stretch::style::Style {
@@ -25,7 +25,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/margin_with_sibling_row.rs
+++ b/benches/generated/margin_with_sibling_row.rs
@@ -7,10 +7,10 @@ pub fn compute() {
                 margin: stretch::geometry::Rect { end: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
-    let node1 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
+    let node1 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node = stretch
         .new_node(
             stretch::style::Style {
@@ -21,7 +21,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/max_height.rs
+++ b/benches/generated/max_height.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -23,7 +23,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/max_height_overrides_height.rs
+++ b/benches/generated/max_height_overrides_height.rs
@@ -13,9 +13,9 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
-    let node = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node0]).unwrap();
+    let node = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node0]).unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/max_height_overrides_height_on_root.rs
+++ b/benches/generated/max_height_overrides_height_on_root.rs
@@ -13,7 +13,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/max_width.rs
+++ b/benches/generated/max_width.rs
@@ -13,7 +13,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -27,7 +27,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/max_width_overrides_width.rs
+++ b/benches/generated/max_width_overrides_width.rs
@@ -13,9 +13,9 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
-    let node = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node0]).unwrap();
+    let node = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node0]).unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/max_width_overrides_width_on_root.rs
+++ b/benches/generated/max_width_overrides_width_on_root.rs
@@ -13,7 +13,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/min_height.rs
+++ b/benches/generated/min_height.rs
@@ -10,10 +10,10 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
-    let node1 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
+    let node1 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node = stretch
         .new_node(
             stretch::style::Style {
@@ -25,7 +25,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/min_height_overrides_height.rs
+++ b/benches/generated/min_height_overrides_height.rs
@@ -13,9 +13,9 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
-    let node = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node0]).unwrap();
+    let node = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node0]).unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/min_height_overrides_height_on_root.rs
+++ b/benches/generated/min_height_overrides_height_on_root.rs
@@ -13,7 +13,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/min_max_percent_no_width_height.rs
+++ b/benches/generated/min_max_percent_no_width_height.rs
@@ -15,7 +15,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -30,7 +30,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/min_width.rs
+++ b/benches/generated/min_width.rs
@@ -10,10 +10,10 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
-    let node1 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
+    let node1 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node = stretch
         .new_node(
             stretch::style::Style {
@@ -24,7 +24,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/min_width_overrides_width.rs
+++ b/benches/generated/min_width_overrides_width.rs
@@ -10,9 +10,9 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
-    let node = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node0]).unwrap();
+    let node = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node0]).unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/min_width_overrides_width_on_root.rs
+++ b/benches/generated/min_width_overrides_width_on_root.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/nested_overflowing_child.rs
+++ b/benches/generated/nested_overflowing_child.rs
@@ -10,10 +10,10 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
-    let node0 = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node00]).unwrap();
+    let node0 = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node00]).unwrap();
     let node = stretch
         .new_node(
             stretch::style::Style {
@@ -24,7 +24,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/nested_overflowing_child_in_constraint_parent.rs
+++ b/benches/generated/nested_overflowing_child_in_constraint_parent.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -23,7 +23,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node = stretch
@@ -36,7 +36,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/overflow_cross_axis.rs
+++ b/benches/generated/overflow_cross_axis.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -23,7 +23,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/overflow_main_axis.rs
+++ b/benches/generated/overflow_main_axis.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -23,7 +23,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/padding_align_end_child.rs
+++ b/benches/generated/padding_align_end_child.rs
@@ -17,7 +17,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -32,7 +32,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/padding_center_child.rs
+++ b/benches/generated/padding_center_child.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -32,7 +32,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/padding_flex_child.rs
+++ b/benches/generated/padding_flex_child.rs
@@ -7,7 +7,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -27,7 +27,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/padding_no_child.rs
+++ b/benches/generated/padding_no_child.rs
@@ -12,7 +12,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/padding_stretch_child.rs
+++ b/benches/generated/padding_stretch_child.rs
@@ -9,7 +9,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -29,7 +29,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/parent_wrap_child_size_overflowing_parent.rs
+++ b/benches/generated/parent_wrap_child_size_overflowing_parent.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -22,7 +22,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node = stretch
@@ -35,7 +35,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/percent_absolute_position.rs
+++ b/benches/generated/percent_absolute_position.rs
@@ -6,7 +6,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Percent(1f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node01 = stretch
@@ -15,7 +15,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Percent(1f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -33,7 +33,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node00, node01],
+            &[node00, node01],
         )
         .unwrap();
     let node = stretch
@@ -47,7 +47,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/percent_within_flex_grow.rs
+++ b/benches/generated/percent_within_flex_grow.rs
@@ -9,7 +9,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node10 = stretch
@@ -18,7 +18,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Percent(1f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -28,7 +28,7 @@ pub fn compute() {
                 flex_grow: 1f32,
                 ..Default::default()
             },
-            vec![node10],
+            &[node10],
         )
         .unwrap();
     let node2 = stretch
@@ -40,7 +40,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -53,7 +53,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/percentage_absolute_position.rs
+++ b/benches/generated/percentage_absolute_position.rs
@@ -16,7 +16,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -30,7 +30,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/percentage_container_in_wrapping_container.rs
+++ b/benches/generated/percentage_container_in_wrapping_container.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node001 = stretch
@@ -23,7 +23,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node00 = stretch
@@ -33,13 +33,13 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Percent(1f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![node000, node001],
+            &[node000, node001],
         )
         .unwrap();
     let node0 = stretch
         .new_node(
             stretch::style::Style { flex_direction: stretch::style::FlexDirection::Column, ..Default::default() },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node = stretch
@@ -55,7 +55,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/percentage_flex_basis.rs
+++ b/benches/generated/percentage_flex_basis.rs
@@ -7,7 +7,7 @@ pub fn compute() {
                 flex_basis: stretch::style::Dimension::Percent(0.5f32),
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -17,7 +17,7 @@ pub fn compute() {
                 flex_basis: stretch::style::Dimension::Percent(0.25f32),
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -30,7 +30,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/percentage_flex_basis_cross.rs
+++ b/benches/generated/percentage_flex_basis_cross.rs
@@ -7,7 +7,7 @@ pub fn compute() {
                 flex_basis: stretch::style::Dimension::Percent(0.5f32),
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -17,7 +17,7 @@ pub fn compute() {
                 flex_basis: stretch::style::Dimension::Percent(0.25f32),
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -31,7 +31,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/percentage_flex_basis_cross_max_height.rs
+++ b/benches/generated/percentage_flex_basis_cross_max_height.rs
@@ -11,7 +11,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -25,7 +25,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -39,7 +39,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/percentage_flex_basis_cross_max_width.rs
+++ b/benches/generated/percentage_flex_basis_cross_max_width.rs
@@ -11,7 +11,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -25,7 +25,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -39,7 +39,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/percentage_flex_basis_cross_min_height.rs
+++ b/benches/generated/percentage_flex_basis_cross_min_height.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -23,7 +23,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -37,7 +37,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/percentage_flex_basis_cross_min_width.rs
+++ b/benches/generated/percentage_flex_basis_cross_min_width.rs
@@ -11,7 +11,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -25,7 +25,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -39,7 +39,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/percentage_flex_basis_main_max_height.rs
+++ b/benches/generated/percentage_flex_basis_main_max_height.rs
@@ -11,7 +11,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -25,7 +25,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -38,7 +38,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/percentage_flex_basis_main_max_width.rs
+++ b/benches/generated/percentage_flex_basis_main_max_width.rs
@@ -11,7 +11,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -25,7 +25,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -38,7 +38,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/percentage_flex_basis_main_min_width.rs
+++ b/benches/generated/percentage_flex_basis_main_min_width.rs
@@ -11,7 +11,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -25,7 +25,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -38,7 +38,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/percentage_margin_should_calculate_based_only_on_width.rs
+++ b/benches/generated/percentage_margin_should_calculate_based_only_on_width.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -27,7 +27,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node = stretch
@@ -41,7 +41,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/percentage_multiple_nested_with_padding_margin_and_percentage_values.rs
+++ b/benches/generated/percentage_multiple_nested_with_padding_margin_and_percentage_values.rs
@@ -23,7 +23,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node00 = stretch
@@ -50,7 +50,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node000],
+            &[node000],
         )
         .unwrap();
     let node0 = stretch
@@ -79,7 +79,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node1 = stretch
@@ -93,7 +93,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -107,7 +107,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/percentage_padding_should_calculate_based_only_on_width.rs
+++ b/benches/generated/percentage_padding_should_calculate_based_only_on_width.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -27,7 +27,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node = stretch
@@ -41,7 +41,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/percentage_position_bottom_right.rs
+++ b/benches/generated/percentage_position_bottom_right.rs
@@ -15,7 +15,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -28,7 +28,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/percentage_position_left_top.rs
+++ b/benches/generated/percentage_position_left_top.rs
@@ -15,7 +15,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -28,7 +28,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/percentage_size_based_on_parent_inner_size.rs
+++ b/benches/generated/percentage_size_based_on_parent_inner_size.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -31,7 +31,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/percentage_size_of_flex_basis.rs
+++ b/benches/generated/percentage_size_of_flex_basis.rs
@@ -10,13 +10,13 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
         .new_node(
             stretch::style::Style { flex_basis: stretch::style::Dimension::Points(50f32), ..Default::default() },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node = stretch
@@ -28,7 +28,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/percentage_width_height.rs
+++ b/benches/generated/percentage_width_height.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -23,7 +23,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/percentage_width_height_undefined_parent_size.rs
+++ b/benches/generated/percentage_width_height_undefined_parent_size.rs
@@ -10,13 +10,13 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
         .new_node(
             stretch::style::Style { flex_direction: stretch::style::FlexDirection::Column, ..Default::default() },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/relative_position_should_not_nudge_siblings.rs
+++ b/benches/generated/relative_position_should_not_nudge_siblings.rs
@@ -13,7 +13,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -29,7 +29,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -43,7 +43,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/rounding_flex_basis_flex_grow_row_prime_number_width.rs
+++ b/benches/generated/rounding_flex_basis_flex_grow_row_prime_number_width.rs
@@ -1,10 +1,10 @@
 pub fn compute() {
     let mut stretch = stretch::Stretch::new();
-    let node0 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
-    let node1 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
-    let node2 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
-    let node3 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
-    let node4 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
+    let node0 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node1 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node2 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node3 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node4 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node = stretch
         .new_node(
             stretch::style::Style {
@@ -15,7 +15,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2, node3, node4],
+            &[node0, node1, node2, node3, node4],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/rounding_flex_basis_flex_grow_row_width_of_100.rs
+++ b/benches/generated/rounding_flex_basis_flex_grow_row_width_of_100.rs
@@ -1,8 +1,8 @@
 pub fn compute() {
     let mut stretch = stretch::Stretch::new();
-    let node0 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
-    let node1 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
-    let node2 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
+    let node0 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node1 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node2 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node = stretch
         .new_node(
             stretch::style::Style {
@@ -13,7 +13,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/rounding_flex_basis_flex_shrink_row.rs
+++ b/benches/generated/rounding_flex_basis_flex_shrink_row.rs
@@ -7,19 +7,19 @@ pub fn compute() {
                 flex_basis: stretch::style::Dimension::Points(100f32),
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
         .new_node(
             stretch::style::Style { flex_basis: stretch::style::Dimension::Points(25f32), ..Default::default() },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
         .new_node(
             stretch::style::Style { flex_basis: stretch::style::Dimension::Points(25f32), ..Default::default() },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -32,7 +32,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/rounding_flex_basis_overrides_main_size.rs
+++ b/benches/generated/rounding_flex_basis_overrides_main_size.rs
@@ -11,7 +11,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -24,7 +24,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -37,7 +37,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -51,7 +51,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/rounding_fractial_input_1.rs
+++ b/benches/generated/rounding_fractial_input_1.rs
@@ -11,7 +11,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -24,7 +24,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -37,7 +37,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -51,7 +51,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/rounding_fractial_input_2.rs
+++ b/benches/generated/rounding_fractial_input_2.rs
@@ -11,7 +11,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -24,7 +24,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -37,7 +37,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -51,7 +51,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/rounding_fractial_input_3.rs
+++ b/benches/generated/rounding_fractial_input_3.rs
@@ -11,7 +11,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -24,7 +24,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -37,7 +37,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -51,7 +51,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/rounding_fractial_input_4.rs
+++ b/benches/generated/rounding_fractial_input_4.rs
@@ -11,7 +11,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -24,7 +24,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -37,7 +37,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -51,7 +51,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/rounding_total_fractial.rs
+++ b/benches/generated/rounding_total_fractial.rs
@@ -11,7 +11,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -24,7 +24,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -37,7 +37,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -51,7 +51,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/rounding_total_fractial_nested.rs
+++ b/benches/generated/rounding_total_fractial_nested.rs
@@ -15,7 +15,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node01 = stretch
@@ -33,7 +33,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -48,7 +48,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node00, node01],
+            &[node00, node01],
         )
         .unwrap();
     let node1 = stretch
@@ -61,7 +61,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -74,7 +74,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -88,7 +88,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/size_defined_by_child.rs
+++ b/benches/generated/size_defined_by_child.rs
@@ -10,9 +10,9 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
-    let node = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node0]).unwrap();
+    let node = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node0]).unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/size_defined_by_child_with_border.rs
+++ b/benches/generated/size_defined_by_child_with_border.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -25,7 +25,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/size_defined_by_child_with_padding.rs
+++ b/benches/generated/size_defined_by_child_with_padding.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -25,7 +25,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/size_defined_by_grand_child.rs
+++ b/benches/generated/size_defined_by_grand_child.rs
@@ -10,10 +10,10 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
-    let node0 = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node00]).unwrap();
-    let node = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node0]).unwrap();
+    let node0 = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node00]).unwrap();
+    let node = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node0]).unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/width_smaller_then_content_with_flex_grow_large_size.rs
+++ b/benches/generated/width_smaller_then_content_with_flex_grow_large_size.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -21,7 +21,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(0f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node10 = stretch
@@ -34,7 +34,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -45,7 +45,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(0f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![node10],
+            &[node10],
         )
         .unwrap();
     let node = stretch
@@ -57,7 +57,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/width_smaller_then_content_with_flex_grow_small_size.rs
+++ b/benches/generated/width_smaller_then_content_with_flex_grow_small_size.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -21,7 +21,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(0f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node10 = stretch
@@ -34,7 +34,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -45,7 +45,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(0f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![node10],
+            &[node10],
         )
         .unwrap();
     let node = stretch
@@ -54,7 +54,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/width_smaller_then_content_with_flex_grow_unconstraint_size.rs
+++ b/benches/generated/width_smaller_then_content_with_flex_grow_unconstraint_size.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -21,7 +21,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(0f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node10 = stretch
@@ -34,7 +34,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -45,9 +45,9 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(0f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![node10],
+            &[node10],
         )
         .unwrap();
-    let node = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node0, node1]).unwrap();
+    let node = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node0, node1]).unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/width_smaller_then_content_with_flex_grow_very_large_size.rs
+++ b/benches/generated/width_smaller_then_content_with_flex_grow_very_large_size.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -21,7 +21,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(0f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node10 = stretch
@@ -34,7 +34,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -45,7 +45,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(0f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![node10],
+            &[node10],
         )
         .unwrap();
     let node = stretch
@@ -57,7 +57,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/wrap_column.rs
+++ b/benches/generated/wrap_column.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -23,7 +23,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -36,7 +36,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node3 = stretch
@@ -49,7 +49,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -64,7 +64,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2, node3],
+            &[node0, node1, node2, node3],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/wrap_nodes_with_content_sizing_margin_cross.rs
+++ b/benches/generated/wrap_nodes_with_content_sizing_margin_cross.rs
@@ -10,13 +10,13 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node00 = stretch
         .new_node(
             stretch::style::Style { flex_direction: stretch::style::FlexDirection::Column, ..Default::default() },
-            vec![node000],
+            &[node000],
         )
         .unwrap();
     let node010 = stretch
@@ -29,7 +29,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node01 = stretch
@@ -39,7 +39,7 @@ pub fn compute() {
                 margin: stretch::geometry::Rect { top: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![node010],
+            &[node010],
         )
         .unwrap();
     let node0 = stretch
@@ -49,7 +49,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(70f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![node00, node01],
+            &[node00, node01],
         )
         .unwrap();
     let node = stretch
@@ -63,7 +63,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/wrap_nodes_with_content_sizing_overflowing_margin.rs
+++ b/benches/generated/wrap_nodes_with_content_sizing_overflowing_margin.rs
@@ -10,13 +10,13 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node00 = stretch
         .new_node(
             stretch::style::Style { flex_direction: stretch::style::FlexDirection::Column, ..Default::default() },
-            vec![node000],
+            &[node000],
         )
         .unwrap();
     let node010 = stretch
@@ -29,7 +29,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node01 = stretch
@@ -39,7 +39,7 @@ pub fn compute() {
                 margin: stretch::geometry::Rect { end: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![node010],
+            &[node010],
         )
         .unwrap();
     let node0 = stretch
@@ -49,7 +49,7 @@ pub fn compute() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(85f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![node00, node01],
+            &[node00, node01],
         )
         .unwrap();
     let node = stretch
@@ -63,7 +63,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/wrap_reverse_column.rs
+++ b/benches/generated/wrap_reverse_column.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -23,7 +23,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -36,7 +36,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node3 = stretch
@@ -49,7 +49,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -64,7 +64,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2, node3],
+            &[node0, node1, node2, node3],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/wrap_reverse_column_fixed_size.rs
+++ b/benches/generated/wrap_reverse_column_fixed_size.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -23,7 +23,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -36,7 +36,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node3 = stretch
@@ -49,7 +49,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node4 = stretch
@@ -62,7 +62,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -78,7 +78,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2, node3, node4],
+            &[node0, node1, node2, node3, node4],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/wrap_reverse_row.rs
+++ b/benches/generated/wrap_reverse_row.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -23,7 +23,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -36,7 +36,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node3 = stretch
@@ -49,7 +49,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -62,7 +62,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2, node3],
+            &[node0, node1, node2, node3],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/wrap_reverse_row_align_content_center.rs
+++ b/benches/generated/wrap_reverse_row_align_content_center.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -23,7 +23,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -36,7 +36,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node3 = stretch
@@ -49,7 +49,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node4 = stretch
@@ -62,7 +62,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -76,7 +76,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2, node3, node4],
+            &[node0, node1, node2, node3, node4],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/wrap_reverse_row_align_content_flex_start.rs
+++ b/benches/generated/wrap_reverse_row_align_content_flex_start.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -23,7 +23,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -36,7 +36,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node3 = stretch
@@ -49,7 +49,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node4 = stretch
@@ -62,7 +62,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -76,7 +76,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2, node3, node4],
+            &[node0, node1, node2, node3, node4],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/wrap_reverse_row_align_content_space_around.rs
+++ b/benches/generated/wrap_reverse_row_align_content_space_around.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -23,7 +23,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -36,7 +36,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node3 = stretch
@@ -49,7 +49,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node4 = stretch
@@ -62,7 +62,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -76,7 +76,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2, node3, node4],
+            &[node0, node1, node2, node3, node4],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/wrap_reverse_row_align_content_stretch.rs
+++ b/benches/generated/wrap_reverse_row_align_content_stretch.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -23,7 +23,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -36,7 +36,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node3 = stretch
@@ -49,7 +49,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node4 = stretch
@@ -62,7 +62,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -75,7 +75,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2, node3, node4],
+            &[node0, node1, node2, node3, node4],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/wrap_reverse_row_single_line_different_size.rs
+++ b/benches/generated/wrap_reverse_row_single_line_different_size.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -23,7 +23,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -36,7 +36,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node3 = stretch
@@ -49,7 +49,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node4 = stretch
@@ -62,7 +62,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -76,7 +76,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2, node3, node4],
+            &[node0, node1, node2, node3, node4],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/wrap_row.rs
+++ b/benches/generated/wrap_row.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -23,7 +23,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -36,7 +36,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node3 = stretch
@@ -49,7 +49,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -62,7 +62,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2, node3],
+            &[node0, node1, node2, node3],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/wrap_row_align_items_center.rs
+++ b/benches/generated/wrap_row_align_items_center.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -23,7 +23,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -36,7 +36,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node3 = stretch
@@ -49,7 +49,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -63,7 +63,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2, node3],
+            &[node0, node1, node2, node3],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/wrap_row_align_items_flex_end.rs
+++ b/benches/generated/wrap_row_align_items_flex_end.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -23,7 +23,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -36,7 +36,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node3 = stretch
@@ -49,7 +49,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -63,7 +63,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2, node3],
+            &[node0, node1, node2, node3],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/wrapped_column_max_height.rs
+++ b/benches/generated/wrapped_column_max_height.rs
@@ -14,7 +14,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -34,7 +34,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -47,7 +47,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -65,7 +65,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/wrapped_column_max_height_flex.rs
+++ b/benches/generated/wrapped_column_max_height_flex.rs
@@ -17,7 +17,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -40,7 +40,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -53,7 +53,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -71,7 +71,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/wrapped_row_within_align_items_center.rs
+++ b/benches/generated/wrapped_row_within_align_items_center.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node01 = stretch
@@ -23,13 +23,13 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
         .new_node(
             stretch::style::Style { flex_wrap: stretch::style::FlexWrap::Wrap, ..Default::default() },
-            vec![node00, node01],
+            &[node00, node01],
         )
         .unwrap();
     let node = stretch
@@ -44,7 +44,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/wrapped_row_within_align_items_flex_end.rs
+++ b/benches/generated/wrapped_row_within_align_items_flex_end.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node01 = stretch
@@ -23,13 +23,13 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
         .new_node(
             stretch::style::Style { flex_wrap: stretch::style::FlexWrap::Wrap, ..Default::default() },
-            vec![node00, node01],
+            &[node00, node01],
         )
         .unwrap();
     let node = stretch
@@ -44,7 +44,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/benches/generated/wrapped_row_within_align_items_flex_start.rs
+++ b/benches/generated/wrapped_row_within_align_items_flex_start.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node01 = stretch
@@ -23,13 +23,13 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
         .new_node(
             stretch::style::Style { flex_wrap: stretch::style::FlexWrap::Wrap, ..Default::default() },
-            vec![node00, node01],
+            &[node00, node01],
         )
         .unwrap();
     let node = stretch
@@ -44,7 +44,7 @@ pub fn compute() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/bindings/js/Cargo.toml
+++ b/bindings/js/Cargo.toml
@@ -13,7 +13,7 @@ default = ["console_error_panic_hook"]
 [dependencies]
 wasm-bindgen = "0.2"
 js-sys = "0.3"
-stretch = "0.3.2"
+stretch = { version = "0.3.2", path = "../.." }
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires

--- a/bindings/kotlin/stretch/src/main/rust/Cargo.toml
+++ b/bindings/kotlin/stretch/src/main/rust/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 jni = { version = "0.14.0", default-features = false }
-stretch = "0.3.2"
+stretch = { version = "0.3.2", path = "../../../../../.." }
 
 [lib]
 name = "stretch"

--- a/bindings/swift/StretchCore/Cargo.toml
+++ b/bindings/swift/StretchCore/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Emil Sjölander <emil@visly.app>"]
 edition = "2018"
 
 [dependencies]
-stretch = "0.3.2"
+stretch = { version = "0.3.2", path = "../../.." }
 
 [lib]
 name = "stretch"

--- a/bindings/swift/StretchCore/src/lib.rs
+++ b/bindings/swift/StretchCore/src/lib.rs
@@ -214,7 +214,7 @@ pub unsafe extern "C" fn stretch_free(stretch: *mut c_void) {
 pub unsafe extern "C" fn stretch_node_create(stretch: *mut c_void, style: *mut c_void) -> *mut c_void {
     let mut stretch = Box::from_raw(stretch as *mut Stretch);
     let style = Box::from_raw(style as *mut Style);
-    let node = stretch.new_node(*style, vec![]).unwrap();
+    let node = stretch.new_node(*style, &[]).unwrap();
 
     Box::leak(style);
     Box::leak(stretch);
@@ -245,10 +245,10 @@ pub unsafe extern "C" fn stretch_node_set_measure(
     stretch
         .set_measure(
             *node,
-            Some(Box::new(move |constraint| {
+            Some(stretch::node::MeasureFunc::Boxed(Box::new(move |constraint| {
                 let size = measure(swift_ptr, constraint.width.or_else(f32::NAN), constraint.height.or_else(f32::NAN));
-                Ok(Size { width: size.width, height: size.height })
-            })),
+                Size { width: size.width, height: size.height }
+            }))),
         )
         .unwrap();
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -5,7 +5,7 @@ fn main() -> Result<(), stretch::Error> {
     let mut stretch = stretch::node::Stretch::new();
     let child = stretch.new_node(
         Style { size: Size { width: Dimension::Percent(0.5), height: Dimension::Auto }, ..Default::default() },
-        vec![],
+        &[],
     )?;
     let node = stretch.new_node(
         Style {
@@ -13,7 +13,7 @@ fn main() -> Result<(), stretch::Error> {
             justify_content: JustifyContent::Center,
             ..Default::default()
         },
-        vec![child],
+        &[child],
     )?;
 
     stretch.compute_layout(node, Size::undefined())?;

--- a/src/algo.rs
+++ b/src/algo.rs
@@ -2,6 +2,7 @@ use core::f32;
 
 use crate::forest::{Forest, NodeData};
 use crate::id::NodeId;
+use crate::node::MeasureFunc;
 use crate::result;
 use crate::style::*;
 use crate::sys;
@@ -195,7 +196,11 @@ impl Forest {
             }
 
             if let Some(ref measure) = self.nodes[node].measure {
-                let result = ComputeResult { size: measure(node_size) };
+                let result = match measure {
+                    MeasureFunc::Raw(measure) => ComputeResult { size: measure(node_size) },
+                    #[cfg(any(feature = "std", feature = "alloc"))]
+                    MeasureFunc::Boxed(measure) => ComputeResult { size: measure(node_size) },
+                };
                 self.nodes[node].layout_cache =
                     Some(result::Cache { node_size, parent_size, perform_layout, result: result.clone() });
                 return result;

--- a/src/algo.rs
+++ b/src/algo.rs
@@ -118,10 +118,10 @@ impl Forest {
         let abs_x = abs_x + layout.location.x;
         let abs_y = abs_y + layout.location.y;
 
-        layout.location.x = layout.location.x.round();
-        layout.location.y = layout.location.y.round();
-        layout.size.width = (abs_x + layout.size.width).round() - abs_x.round();
-        layout.size.height = (abs_y + layout.size.height).round() - abs_y.round();
+        layout.location.x = sys::round(layout.location.x);
+        layout.location.y = sys::round(layout.location.y);
+        layout.size.width = sys::round(abs_x + layout.size.width) - sys::round(abs_x);
+        layout.size.height = sys::round(abs_y + layout.size.height) - sys::round(abs_y);
         for child in &children[root] {
             Self::round_layout(nodes, children, *child, abs_x, abs_y);
         }
@@ -141,13 +141,13 @@ impl Forest {
         if let Some(ref cache) = self.nodes[node].layout_cache {
             if cache.perform_layout || !perform_layout {
                 let width_compatible = if let Number::Defined(width) = node_size.width {
-                    (width - cache.result.size.width).abs() < f32::EPSILON
+                    sys::abs(width - cache.result.size.width) < f32::EPSILON
                 } else {
                     cache.node_size.width.is_undefined()
                 };
 
                 let height_compatible = if let Number::Defined(height) = node_size.height {
-                    (height - cache.result.size.height).abs() < f32::EPSILON
+                    sys::abs(height - cache.result.size.height) < f32::EPSILON
                 } else {
                     cache.node_size.height.is_undefined()
                 };

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -101,7 +101,7 @@ impl Size<()> {
 }
 
 impl<T> Size<T> {
-    pub(crate) fn map<R, F>(self, f: F) -> Size<R>
+    pub fn map<R, F>(self, f: F) -> Size<R>
     where
         F: Fn(T) -> R,
     {

--- a/src/id.rs
+++ b/src/id.rs
@@ -8,15 +8,15 @@ pub(crate) type NodeId = usize;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(not(any(feature = "std", feature = "alloc")), derive(hash32_derive::Hash32))]
-pub(crate) struct Id(u64);
+pub(crate) struct Id(usize);
 
 pub(crate) struct Allocator {
-    new_id: atomic::AtomicU64,
+    new_id: atomic::AtomicUsize,
 }
 
 impl Allocator {
     pub const fn new() -> Self {
-        Allocator { new_id: atomic::AtomicU64::new(0) }
+        Allocator { new_id: atomic::AtomicUsize::new(0) }
     }
 
     pub fn allocate(&self) -> Id {

--- a/src/id.rs
+++ b/src/id.rs
@@ -1,124 +1,27 @@
 //! Identifier for a Node
 //!
 //!
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
 use core::sync::atomic;
 
 /// Internal node id.
 pub(crate) type NodeId = usize;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub(crate) struct Id {
-    id: u32,
-    generation: u32,
-}
+#[cfg_attr(not(any(feature = "std", feature = "alloc")), derive(hash32_derive::Hash32))]
+pub(crate) struct Id(u64);
 
 pub(crate) struct Allocator {
-    new_id: atomic::AtomicU32,
-    free_ids: spin::RwLock<IdCache>,
+    new_id: atomic::AtomicU64,
 }
 
 impl Allocator {
     pub fn new() -> Self {
-        Allocator { new_id: atomic::AtomicU32::new(0), free_ids: spin::RwLock::new(IdCache::default()) }
+        Allocator { new_id: atomic::AtomicU64::new(0) }
     }
 
     pub fn allocate(&self) -> Id {
-        self.free_ids
-            .read()
-            .pop_atomic()
-            .map(|Id { id, generation }| Id { id, generation: generation + 1 })
-            .unwrap_or_else(|| Id {
-                id: atomic_increment(&self.new_id).expect("No entity left to allocate"),
-                generation: 0,
-            })
+        Id(self.new_id.fetch_add(1, atomic::Ordering::Relaxed))
     }
 
-    pub fn free(&self, ids: &[Id]) {
-        self.free_ids.write().extend(ids.iter().copied());
-    }
-}
-
-// Code below this line is based on code from the `specs` library, in the `src/world/entity.rs`
-// file, which has the following copyright notice (MIT license):
-
-/*
-Copyright (c) 2017 The Specs Project Developers
-
-Permission is hereby granted, free of charge, to any
-person obtaining a copy of this software and associated
-documentation files (the "Software"), to deal in the
-Software without restriction, including without
-limitation the rights to use, copy, modify, merge,
-publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software
-is furnished to do so, subject to the following
-conditions:
-
-The above copyright notice and this permission notice
-shall be included in all copies or substantial portions
-of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
-ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
-*/
-
-#[derive(Default, Debug)]
-struct IdCache {
-    cache: Vec<Id>,
-    len: atomic::AtomicUsize,
-}
-
-impl IdCache {
-    fn pop_atomic(&self) -> Option<Id> {
-        atomic_decrement(&self.len).map(|x| self.cache[x - 1])
-    }
-
-    fn maintain(&mut self) {
-        self.cache.truncate(*(self.len.get_mut()));
-    }
-}
-
-impl Extend<Id> for IdCache {
-    fn extend<T: IntoIterator<Item = Id>>(&mut self, iter: T) {
-        self.maintain();
-        self.cache.extend(iter);
-        *self.len.get_mut() = self.cache.len();
-    }
-}
-
-/// Increments `i` atomically without wrapping on overflow.
-/// Resembles a `fetch_add(1, Ordering::Relaxed)` with
-/// checked overflow, returning `None` instead.
-fn atomic_increment(i: &atomic::AtomicU32) -> Option<u32> {
-    let mut prev = i.load(atomic::Ordering::Relaxed);
-    while prev != core::u32::MAX {
-        match i.compare_exchange_weak(prev, prev + 1, atomic::Ordering::Relaxed, atomic::Ordering::Relaxed) {
-            Ok(x) => return Some(x),
-            Err(next_prev) => prev = next_prev,
-        }
-    }
-    None
-}
-
-/// Decrements `i` atomically without wrapping on overflow.
-/// Resembles a `fetch_sub(1, Ordering::Relaxed)` with
-/// checked underflow, returning `None` instead.
-fn atomic_decrement(i: &atomic::AtomicUsize) -> Option<usize> {
-    let mut prev = i.load(atomic::Ordering::Relaxed);
-    while prev != 0 {
-        match i.compare_exchange_weak(prev, prev - 1, atomic::Ordering::Relaxed, atomic::Ordering::Relaxed) {
-            Ok(x) => return Some(x),
-            Err(next_prev) => prev = next_prev,
-        }
-    }
-    None
+    pub fn free(&self, _ids: &[Id]) {}
 }

--- a/src/id.rs
+++ b/src/id.rs
@@ -15,7 +15,7 @@ pub(crate) struct Allocator {
 }
 
 impl Allocator {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Allocator { new_id: atomic::AtomicU64::new(0) }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ mod algo;
 mod forest;
 mod id;
 
+mod sys;
 pub use crate::node::Stretch;
 
 use core::any::Any;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#[cfg(not(feature = "std"))]
-extern crate alloc;
 
-#[cfg(not(feature = "std"))]
-use alloc::boxed::Box;
+#[cfg(all(not(feature = "std"), feature = "alloc"))]
+extern crate alloc;
 
 #[macro_use]
 extern crate lazy_static;
@@ -23,14 +21,12 @@ mod forest;
 mod id;
 
 mod sys;
-pub use crate::node::Stretch;
 
-use core::any::Any;
+pub use crate::node::Stretch;
 
 #[derive(Debug)]
 pub enum Error {
     InvalidNode(node::Node),
-    Measure(Box<dyn Any>),
 }
 
 #[cfg(feature = "std")]
@@ -38,7 +34,6 @@ impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match *self {
             Error::InvalidNode(ref node) => write!(f, "Invalid node {:?}", node),
-            Error::Measure(_) => write!(f, "Error during measurement"),
         }
     }
 }
@@ -48,7 +43,6 @@ impl std::error::Error for Error {
     fn description(&self) -> &str {
         match *self {
             Error::InvalidNode(_) => "The node is not part of the stretch instance",
-            Error::Measure(_) => "Error occurred inside a measurement function",
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,6 @@
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 extern crate alloc;
 
-#[macro_use]
-extern crate lazy_static;
-
 #[cfg_attr(feature = "serde", macro_use)]
 #[cfg(feature = "serde")]
 extern crate serde;

--- a/src/node.rs
+++ b/src/node.rs
@@ -15,10 +15,8 @@ pub enum MeasureFunc {
     Boxed(sys::Box<dyn Fn(Size<Number>) -> Size<f32>>),
 }
 
-lazy_static! {
-    /// Global stretch instance id allocator.
-    static ref INSTANCE_ALLOCATOR: id::Allocator = id::Allocator::new();
-}
+/// Global stretch instance id allocator.
+static INSTANCE_ALLOCATOR: id::Allocator = id::Allocator::new();
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(not(any(feature = "std", feature = "alloc")), derive(hash32_derive::Hash32))]

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,11 +1,3 @@
-#[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, vec::Vec};
-#[cfg(not(feature = "std"))]
-use hashbrown::HashMap;
-#[cfg(feature = "std")]
-use std::collections::HashMap;
-
-use core::any::Any;
 use core::ops::Drop;
 
 use crate::forest::Forest;
@@ -14,9 +6,10 @@ use crate::id::{self, NodeId};
 use crate::number::Number;
 use crate::result::Layout;
 use crate::style::*;
+use crate::sys;
 use crate::Error;
 
-pub type MeasureFunc = Box<dyn Fn(Size<Number>) -> Result<Size<f32>, Box<dyn Any>>>;
+pub type MeasureFunc = fn(Size<Number>) -> Size<f32>;
 
 lazy_static! {
     /// Global stretch instance id allocator.
@@ -24,6 +17,7 @@ lazy_static! {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(not(any(feature = "std", feature = "alloc")), derive(hash32_derive::Hash32))]
 pub struct Node {
     instance: id::Id,
     local: id::Id,
@@ -32,8 +26,8 @@ pub struct Node {
 pub struct Stretch {
     id: id::Id,
     nodes: id::Allocator,
-    nodes_to_ids: HashMap<Node, NodeId>,
-    ids_to_nodes: HashMap<NodeId, Node>,
+    nodes_to_ids: crate::sys::Map<Node, NodeId>,
+    ids_to_nodes: crate::sys::Map<NodeId, Node>,
     forest: Forest,
 }
 
@@ -52,8 +46,8 @@ impl Stretch {
         Stretch {
             id: INSTANCE_ALLOCATOR.allocate(),
             nodes: id::Allocator::new(),
-            nodes_to_ids: HashMap::with_capacity(capacity),
-            ids_to_nodes: HashMap::with_capacity(capacity),
+            nodes_to_ids: crate::sys::new_map_with_capacity(capacity),
+            ids_to_nodes: crate::sys::new_map_with_capacity(capacity),
             forest: Forest::with_capacity(capacity),
         }
     }
@@ -64,8 +58,8 @@ impl Stretch {
     }
 
     fn add_node(&mut self, node: Node, id: NodeId) {
-        self.nodes_to_ids.insert(node, id);
-        self.ids_to_nodes.insert(id, node);
+        let _ = self.nodes_to_ids.insert(node, id);
+        let _ = self.ids_to_nodes.insert(id, node);
     }
 
     // Find node in the forest.
@@ -83,9 +77,10 @@ impl Stretch {
         Ok(node)
     }
 
-    pub fn new_node(&mut self, style: Style, children: Vec<Node>) -> Result<Node, Error> {
+    pub fn new_node(&mut self, style: Style, children: &[Node]) -> Result<Node, Error> {
         let node = self.allocate_node();
-        let children = children.iter().map(|child| self.find_node(*child)).collect::<Result<Vec<_>, Error>>()?;
+        let children =
+            children.iter().map(|child| self.find_node(*child)).collect::<Result<sys::ChildrenVec<_>, Error>>()?;
         let id = self.forest.new_node(style, children);
         self.add_node(node, id);
         Ok(node)
@@ -112,8 +107,8 @@ impl Stretch {
 
         if let Some(new_id) = self.forest.swap_remove(id) {
             let new = self.ids_to_nodes.remove(&new_id).unwrap();
-            self.nodes_to_ids.insert(new, id);
-            self.ids_to_nodes.insert(id, new);
+            let _ = self.nodes_to_ids.insert(new, id);
+            let _ = self.ids_to_nodes.insert(id, new);
         }
     }
 
@@ -132,9 +127,10 @@ impl Stretch {
         Ok(())
     }
 
-    pub fn set_children(&mut self, node: Node, children: Vec<Node>) -> Result<(), Error> {
+    pub fn set_children(&mut self, node: Node, children: &[Node]) -> Result<(), Error> {
         let node_id = self.find_node(node)?;
-        let children_id = children.iter().map(|child| self.find_node(*child)).collect::<Result<Vec<_>, _>>()?;
+        let children_id =
+            children.iter().map(|child| self.find_node(*child)).collect::<Result<sys::ChildrenVec<_>, _>>()?;
 
         // Remove node as parent from all its current children.
         for child in &self.forest.children[node_id] {
@@ -181,7 +177,7 @@ impl Stretch {
         Ok(self.ids_to_nodes[&old_child])
     }
 
-    pub fn children(&self, node: Node) -> Result<Vec<Node>, Error> {
+    pub fn children(&self, node: Node) -> Result<sys::Vec<Node>, Error> {
         let id = self.find_node(node)?;
         Ok(self.forest.children[id].iter().map(|child| self.ids_to_nodes[child]).collect())
     }
@@ -226,7 +222,8 @@ impl Stretch {
 
     pub fn compute_layout(&mut self, node: Node, size: Size<Number>) -> Result<(), Error> {
         let id = self.find_node(node)?;
-        self.forest.compute_layout(id, size)
+        self.forest.compute_layout(id, size);
+        Ok(())
     }
 }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -186,6 +186,11 @@ impl Stretch {
         Ok(self.forest.children[id].iter().map(|child| self.ids_to_nodes[child]).collect())
     }
 
+    pub fn child_at_index(&self, node: Node, index: usize) -> Result<Node, Error> {
+        let id = self.find_node(node)?;
+        Ok(self.ids_to_nodes[&self.forest.children[id][index]])
+    }
+
     pub fn child_count(&self, node: Node) -> Result<usize, Error> {
         let id = self.find_node(node)?;
         Ok(self.forest.children[id].len())

--- a/src/node.rs
+++ b/src/node.rs
@@ -9,7 +9,11 @@ use crate::style::*;
 use crate::sys;
 use crate::Error;
 
-pub type MeasureFunc = fn(Size<Number>) -> Size<f32>;
+pub enum MeasureFunc {
+    Raw(fn(Size<Number>) -> Size<f32>),
+    #[cfg(any(feature = "std", feature = "alloc"))]
+    Boxed(sys::Box<dyn Fn(Size<Number>) -> Size<f32>>),
+}
 
 lazy_static! {
     /// Global stretch instance id allocator.

--- a/src/style.rs
+++ b/src/style.rs
@@ -236,7 +236,7 @@ impl Default for Size<Dimension> {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(default))]
 #[cfg_attr(all(feature = "serde", feature = "serde_kebab_case"), serde(rename_all = "kebab-case"))]

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -1,0 +1,69 @@
+#[cfg(feature = "std")]
+mod std {
+    pub type Map<K, V> = ::std::collections::HashMap<K, V>;
+    pub type Vec<A> = ::std::vec::Vec<A>;
+    pub type ChildrenVec<A> = ::std::vec::Vec<A>;
+    pub type ParentsVec<A> = ::std::vec::Vec<A>;
+
+    pub fn new_map_with_capacity<K, V>(capacity: usize) -> Map<K, V>
+    where
+        K: Eq + ::std::hash::Hash,
+    {
+        Map::with_capacity(capacity)
+    }
+
+    pub fn new_vec_with_capacity<A>(capacity: usize) -> Vec<A> {
+        Vec::with_capacity(capacity)
+    }
+}
+
+#[cfg(feature = "alloc")]
+mod alloc {
+    pub type Map<K, V> = ::hashbrown::HashMap<K, V>;
+    pub type Vec<A> = ::alloc::vec::Vec<A>;
+    pub type ChildrenVec<A> = ::alloc::vec::Vec<A>;
+    pub type ParentsVec<A> = ::alloc::vec::Vec<A>;
+
+    pub fn new_map_with_capacity<K, V>(capacity: usize) -> Map<K, V> {
+        Map::with_capacity(capacity)
+    }
+
+    pub fn new_vec_with_capacity<A>(capacity: usize) -> Vec<A> {
+        Vec::with_capacity(capacity)
+    }
+}
+
+#[cfg(all(not(feature = "alloc"), not(feature = "std")))]
+mod core {
+    use typenum::marker_traits::Unsigned;
+
+    type MaxNodeCount = heapless::consts::U256;
+    type MaxChildCount = heapless::consts::U16;
+    type MaxParentsCount = heapless::consts::U1;
+
+    pub type Map<K, V> = ::heapless::FnvIndexMap<K, V, MaxNodeCount>;
+    pub type Vec<A> = ::arrayvec::ArrayVec<[A; MaxNodeCount::USIZE]>;
+    pub type ChildrenVec<A> = ::arrayvec::ArrayVec<[A; MaxChildCount::USIZE]>;
+    pub type ParentsVec<A> = ::arrayvec::ArrayVec<[A; MaxParentsCount::USIZE]>;
+
+    pub fn new_map_with_capacity<K, V>(_capacity: usize) -> Map<K, V>
+    where
+        K: Eq + ::hash32::Hash,
+    {
+        Map::new()
+    }
+
+    pub fn new_vec_with_capacity<T, A>(_capacity: usize) -> ::arrayvec::ArrayVec<A>
+    where
+        A: ::arrayvec::Array<Item = T>,
+    {
+        ::arrayvec::ArrayVec::new()
+    }
+}
+
+#[cfg(feature = "alloc")]
+pub use self::alloc::*;
+#[cfg(all(not(feature = "alloc"), not(feature = "std")))]
+pub use self::core::*;
+#[cfg(feature = "std")]
+pub use self::std::*;

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "std")]
 mod std {
+    pub type Box<A> = ::std::boxed::Box<A>;
     pub type Map<K, V> = ::std::collections::HashMap<K, V>;
     pub type Vec<A> = ::std::vec::Vec<A>;
     pub type ChildrenVec<A> = ::std::vec::Vec<A>;
@@ -19,6 +20,7 @@ mod std {
 
 #[cfg(feature = "alloc")]
 mod alloc {
+    pub type Box<A> = ::alloc::boxed::Box<A>;
     pub type Map<K, V> = ::hashbrown::HashMap<K, V>;
     pub type Vec<A> = ::alloc::vec::Vec<A>;
     pub type ChildrenVec<A> = ::alloc::vec::Vec<A>;

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -16,6 +16,16 @@ mod std {
     pub fn new_vec_with_capacity<A>(capacity: usize) -> Vec<A> {
         Vec::with_capacity(capacity)
     }
+
+    #[inline]
+    pub fn round(value: f32) -> f32 {
+        value.round()
+    }
+
+    #[inline]
+    pub fn abs(value: f32) -> f32 {
+        value.abs()
+    }
 }
 
 #[cfg(feature = "alloc")]
@@ -32,6 +42,16 @@ mod alloc {
 
     pub fn new_vec_with_capacity<A>(capacity: usize) -> Vec<A> {
         Vec::with_capacity(capacity)
+    }
+
+    #[inline]
+    pub fn round(value: f32) -> f32 {
+        num_traits::float::FloatCore::round(value)
+    }
+
+    #[inline]
+    pub fn abs(value: f32) -> f32 {
+        num_traits::float::FloatCore::abs(value)
     }
 }
 
@@ -60,6 +80,16 @@ mod core {
         A: ::arrayvec::Array<Item = T>,
     {
         ::arrayvec::ArrayVec::new()
+    }
+
+    #[inline]
+    pub fn round(value: f32) -> f32 {
+        num_traits::float::FloatCore::round(value)
+    }
+
+    #[inline]
+    pub fn abs(value: f32) -> f32 {
+        num_traits::float::FloatCore::abs(value)
     }
 }
 

--- a/tests/generated/absolute_layout_align_items_and_justify_content_center.rs
+++ b/tests/generated/absolute_layout_align_items_and_justify_content_center.rs
@@ -12,7 +12,7 @@ fn absolute_layout_align_items_and_justify_content_center() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -27,7 +27,7 @@ fn absolute_layout_align_items_and_justify_content_center() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/absolute_layout_align_items_and_justify_content_center_and_bottom_position.rs
+++ b/tests/generated/absolute_layout_align_items_and_justify_content_center_and_bottom_position.rs
@@ -16,7 +16,7 @@ fn absolute_layout_align_items_and_justify_content_center_and_bottom_position() 
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -31,7 +31,7 @@ fn absolute_layout_align_items_and_justify_content_center_and_bottom_position() 
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/absolute_layout_align_items_and_justify_content_center_and_left_position.rs
+++ b/tests/generated/absolute_layout_align_items_and_justify_content_center_and_left_position.rs
@@ -16,7 +16,7 @@ fn absolute_layout_align_items_and_justify_content_center_and_left_position() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -31,7 +31,7 @@ fn absolute_layout_align_items_and_justify_content_center_and_left_position() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/absolute_layout_align_items_and_justify_content_center_and_right_position.rs
+++ b/tests/generated/absolute_layout_align_items_and_justify_content_center_and_right_position.rs
@@ -16,7 +16,7 @@ fn absolute_layout_align_items_and_justify_content_center_and_right_position() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -31,7 +31,7 @@ fn absolute_layout_align_items_and_justify_content_center_and_right_position() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/absolute_layout_align_items_and_justify_content_center_and_top_position.rs
+++ b/tests/generated/absolute_layout_align_items_and_justify_content_center_and_top_position.rs
@@ -16,7 +16,7 @@ fn absolute_layout_align_items_and_justify_content_center_and_top_position() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -31,7 +31,7 @@ fn absolute_layout_align_items_and_justify_content_center_and_top_position() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/absolute_layout_align_items_and_justify_content_flex_end.rs
+++ b/tests/generated/absolute_layout_align_items_and_justify_content_flex_end.rs
@@ -12,7 +12,7 @@ fn absolute_layout_align_items_and_justify_content_flex_end() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -27,7 +27,7 @@ fn absolute_layout_align_items_and_justify_content_flex_end() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/absolute_layout_align_items_center.rs
+++ b/tests/generated/absolute_layout_align_items_center.rs
@@ -12,7 +12,7 @@ fn absolute_layout_align_items_center() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -26,7 +26,7 @@ fn absolute_layout_align_items_center() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/absolute_layout_align_items_center_on_child_only.rs
+++ b/tests/generated/absolute_layout_align_items_center_on_child_only.rs
@@ -13,7 +13,7 @@ fn absolute_layout_align_items_center_on_child_only() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -26,7 +26,7 @@ fn absolute_layout_align_items_center_on_child_only() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/absolute_layout_child_order.rs
+++ b/tests/generated/absolute_layout_child_order.rs
@@ -11,7 +11,7 @@ fn absolute_layout_child_order() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -25,7 +25,7 @@ fn absolute_layout_child_order() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -38,7 +38,7 @@ fn absolute_layout_child_order() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -53,7 +53,7 @@ fn absolute_layout_child_order() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/absolute_layout_in_wrap_reverse_column_container.rs
+++ b/tests/generated/absolute_layout_in_wrap_reverse_column_container.rs
@@ -12,7 +12,7 @@ fn absolute_layout_in_wrap_reverse_column_container() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -27,7 +27,7 @@ fn absolute_layout_in_wrap_reverse_column_container() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/absolute_layout_in_wrap_reverse_column_container_flex_end.rs
+++ b/tests/generated/absolute_layout_in_wrap_reverse_column_container_flex_end.rs
@@ -13,7 +13,7 @@ fn absolute_layout_in_wrap_reverse_column_container_flex_end() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -28,7 +28,7 @@ fn absolute_layout_in_wrap_reverse_column_container_flex_end() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/absolute_layout_in_wrap_reverse_row_container.rs
+++ b/tests/generated/absolute_layout_in_wrap_reverse_row_container.rs
@@ -12,7 +12,7 @@ fn absolute_layout_in_wrap_reverse_row_container() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -26,7 +26,7 @@ fn absolute_layout_in_wrap_reverse_row_container() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/absolute_layout_in_wrap_reverse_row_container_flex_end.rs
+++ b/tests/generated/absolute_layout_in_wrap_reverse_row_container_flex_end.rs
@@ -13,7 +13,7 @@ fn absolute_layout_in_wrap_reverse_row_container_flex_end() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -27,7 +27,7 @@ fn absolute_layout_in_wrap_reverse_row_container_flex_end() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/absolute_layout_justify_content_center.rs
+++ b/tests/generated/absolute_layout_justify_content_center.rs
@@ -12,7 +12,7 @@ fn absolute_layout_justify_content_center() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -26,7 +26,7 @@ fn absolute_layout_justify_content_center() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/absolute_layout_no_size.rs
+++ b/tests/generated/absolute_layout_no_size.rs
@@ -4,7 +4,7 @@ fn absolute_layout_no_size() {
     let node0 = stretch
         .new_node(
             stretch::style::Style { position_type: stretch::style::PositionType::Absolute, ..Default::default() },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -17,7 +17,7 @@ fn absolute_layout_no_size() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/absolute_layout_percentage_bottom_based_on_parent_height.rs
+++ b/tests/generated/absolute_layout_percentage_bottom_based_on_parent_height.rs
@@ -16,7 +16,7 @@ fn absolute_layout_percentage_bottom_based_on_parent_height() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -34,7 +34,7 @@ fn absolute_layout_percentage_bottom_based_on_parent_height() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -49,7 +49,7 @@ fn absolute_layout_percentage_bottom_based_on_parent_height() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -62,7 +62,7 @@ fn absolute_layout_percentage_bottom_based_on_parent_height() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/absolute_layout_start_top_end_bottom.rs
+++ b/tests/generated/absolute_layout_start_top_end_bottom.rs
@@ -14,7 +14,7 @@ fn absolute_layout_start_top_end_bottom() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -27,7 +27,7 @@ fn absolute_layout_start_top_end_bottom() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/absolute_layout_width_height_end_bottom.rs
+++ b/tests/generated/absolute_layout_width_height_end_bottom.rs
@@ -17,7 +17,7 @@ fn absolute_layout_width_height_end_bottom() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -30,7 +30,7 @@ fn absolute_layout_width_height_end_bottom() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/absolute_layout_width_height_start_top.rs
+++ b/tests/generated/absolute_layout_width_height_start_top.rs
@@ -17,7 +17,7 @@ fn absolute_layout_width_height_start_top() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -30,7 +30,7 @@ fn absolute_layout_width_height_start_top() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/absolute_layout_width_height_start_top_end_bottom.rs
+++ b/tests/generated/absolute_layout_width_height_start_top_end_bottom.rs
@@ -19,7 +19,7 @@ fn absolute_layout_width_height_start_top_end_bottom() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -32,7 +32,7 @@ fn absolute_layout_width_height_start_top_end_bottom() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/absolute_layout_within_border.rs
+++ b/tests/generated/absolute_layout_within_border.rs
@@ -17,7 +17,7 @@ fn absolute_layout_within_border() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -36,7 +36,7 @@ fn absolute_layout_within_border() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -62,7 +62,7 @@ fn absolute_layout_within_border() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node3 = stretch
@@ -88,7 +88,7 @@ fn absolute_layout_within_border() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -115,7 +115,7 @@ fn absolute_layout_within_border() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2, node3],
+            &[node0, node1, node2, node3],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/align_baseline.rs
+++ b/tests/generated/align_baseline.rs
@@ -11,7 +11,7 @@ fn align_baseline() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -24,7 +24,7 @@ fn align_baseline() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -38,7 +38,7 @@ fn align_baseline() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/align_baseline_child_multiline.rs
+++ b/tests/generated/align_baseline_child_multiline.rs
@@ -11,7 +11,7 @@ fn align_baseline_child_multiline() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node10 = stretch
@@ -24,7 +24,7 @@ fn align_baseline_child_multiline() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node11 = stretch
@@ -37,7 +37,7 @@ fn align_baseline_child_multiline() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node12 = stretch
@@ -50,7 +50,7 @@ fn align_baseline_child_multiline() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node13 = stretch
@@ -63,7 +63,7 @@ fn align_baseline_child_multiline() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -73,7 +73,7 @@ fn align_baseline_child_multiline() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(50f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![node10, node11, node12, node13],
+            &[node10, node11, node12, node13],
         )
         .unwrap();
     let node = stretch
@@ -86,7 +86,7 @@ fn align_baseline_child_multiline() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/align_baseline_nested_child.rs
+++ b/tests/generated/align_baseline_nested_child.rs
@@ -11,7 +11,7 @@ fn align_baseline_nested_child() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node10 = stretch
@@ -24,7 +24,7 @@ fn align_baseline_nested_child() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -38,7 +38,7 @@ fn align_baseline_nested_child() {
                 },
                 ..Default::default()
             },
-            vec![node10],
+            &[node10],
         )
         .unwrap();
     let node = stretch
@@ -52,7 +52,7 @@ fn align_baseline_nested_child() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/align_center_should_size_based_on_content.rs
+++ b/tests/generated/align_center_should_size_based_on_content.rs
@@ -11,11 +11,11 @@ fn align_center_should_size_based_on_content() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node00 = stretch
-        .new_node(stretch::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, vec![node000])
+        .new_node(stretch::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[node000])
         .unwrap();
     let node0 = stretch
         .new_node(
@@ -25,7 +25,7 @@ fn align_center_should_size_based_on_content() {
                 flex_shrink: 1f32,
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node = stretch
@@ -39,7 +39,7 @@ fn align_center_should_size_based_on_content() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/align_flex_start_with_shrinking_children.rs
+++ b/tests/generated/align_flex_start_with_shrinking_children.rs
@@ -2,15 +2,15 @@
 fn align_flex_start_with_shrinking_children() {
     let mut stretch = stretch::Stretch::new();
     let node000 = stretch
-        .new_node(stretch::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, vec![])
+        .new_node(stretch::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[])
         .unwrap();
     let node00 = stretch
-        .new_node(stretch::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, vec![node000])
+        .new_node(stretch::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[node000])
         .unwrap();
     let node0 = stretch
         .new_node(
             stretch::style::Style { align_items: stretch::style::AlignItems::FlexStart, ..Default::default() },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node = stretch
@@ -23,7 +23,7 @@ fn align_flex_start_with_shrinking_children() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/align_flex_start_with_shrinking_children_with_stretch.rs
+++ b/tests/generated/align_flex_start_with_shrinking_children_with_stretch.rs
@@ -2,15 +2,15 @@
 fn align_flex_start_with_shrinking_children_with_stretch() {
     let mut stretch = stretch::Stretch::new();
     let node000 = stretch
-        .new_node(stretch::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, vec![])
+        .new_node(stretch::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[])
         .unwrap();
     let node00 = stretch
-        .new_node(stretch::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, vec![node000])
+        .new_node(stretch::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[node000])
         .unwrap();
     let node0 = stretch
         .new_node(
             stretch::style::Style { align_items: stretch::style::AlignItems::FlexStart, ..Default::default() },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node = stretch
@@ -23,7 +23,7 @@ fn align_flex_start_with_shrinking_children_with_stretch() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/align_flex_start_with_stretching_children.rs
+++ b/tests/generated/align_flex_start_with_stretching_children.rs
@@ -2,12 +2,12 @@
 fn align_flex_start_with_stretching_children() {
     let mut stretch = stretch::Stretch::new();
     let node000 = stretch
-        .new_node(stretch::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, vec![])
+        .new_node(stretch::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[])
         .unwrap();
     let node00 = stretch
-        .new_node(stretch::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, vec![node000])
+        .new_node(stretch::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[node000])
         .unwrap();
-    let node0 = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node00]).unwrap();
+    let node0 = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node00]).unwrap();
     let node = stretch
         .new_node(
             stretch::style::Style {
@@ -18,7 +18,7 @@ fn align_flex_start_with_stretching_children() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/align_items_center.rs
+++ b/tests/generated/align_items_center.rs
@@ -11,7 +11,7 @@ fn align_items_center() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -25,7 +25,7 @@ fn align_items_center() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/align_items_center_child_with_margin_bigger_than_parent.rs
+++ b/tests/generated/align_items_center_child_with_margin_bigger_than_parent.rs
@@ -16,13 +16,13 @@ fn align_items_center_child_with_margin_bigger_than_parent() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
         .new_node(
             stretch::style::Style { align_items: stretch::style::AlignItems::Center, ..Default::default() },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node = stretch
@@ -37,7 +37,7 @@ fn align_items_center_child_with_margin_bigger_than_parent() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/align_items_center_child_without_margin_bigger_than_parent.rs
+++ b/tests/generated/align_items_center_child_without_margin_bigger_than_parent.rs
@@ -11,13 +11,13 @@ fn align_items_center_child_without_margin_bigger_than_parent() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
         .new_node(
             stretch::style::Style { align_items: stretch::style::AlignItems::Center, ..Default::default() },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node = stretch
@@ -32,7 +32,7 @@ fn align_items_center_child_without_margin_bigger_than_parent() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/align_items_center_with_child_margin.rs
+++ b/tests/generated/align_items_center_with_child_margin.rs
@@ -12,7 +12,7 @@ fn align_items_center_with_child_margin() {
                 margin: stretch::geometry::Rect { top: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -26,7 +26,7 @@ fn align_items_center_with_child_margin() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/align_items_center_with_child_top.rs
+++ b/tests/generated/align_items_center_with_child_top.rs
@@ -15,7 +15,7 @@ fn align_items_center_with_child_top() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -29,7 +29,7 @@ fn align_items_center_with_child_top() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/align_items_flex_end.rs
+++ b/tests/generated/align_items_flex_end.rs
@@ -11,7 +11,7 @@ fn align_items_flex_end() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -25,7 +25,7 @@ fn align_items_flex_end() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/align_items_flex_end_child_with_margin_bigger_than_parent.rs
+++ b/tests/generated/align_items_flex_end_child_with_margin_bigger_than_parent.rs
@@ -16,13 +16,13 @@ fn align_items_flex_end_child_with_margin_bigger_than_parent() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
         .new_node(
             stretch::style::Style { align_items: stretch::style::AlignItems::FlexEnd, ..Default::default() },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node = stretch
@@ -37,7 +37,7 @@ fn align_items_flex_end_child_with_margin_bigger_than_parent() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/align_items_flex_end_child_without_margin_bigger_than_parent.rs
+++ b/tests/generated/align_items_flex_end_child_without_margin_bigger_than_parent.rs
@@ -11,13 +11,13 @@ fn align_items_flex_end_child_without_margin_bigger_than_parent() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
         .new_node(
             stretch::style::Style { align_items: stretch::style::AlignItems::FlexEnd, ..Default::default() },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node = stretch
@@ -32,7 +32,7 @@ fn align_items_flex_end_child_without_margin_bigger_than_parent() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/align_items_flex_start.rs
+++ b/tests/generated/align_items_flex_start.rs
@@ -11,7 +11,7 @@ fn align_items_flex_start() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -25,7 +25,7 @@ fn align_items_flex_start() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/align_items_min_max.rs
+++ b/tests/generated/align_items_min_max.rs
@@ -11,7 +11,7 @@ fn align_items_min_max() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -33,7 +33,7 @@ fn align_items_min_max() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/align_items_stretch.rs
+++ b/tests/generated/align_items_stretch.rs
@@ -7,7 +7,7 @@ fn align_items_stretch() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -20,7 +20,7 @@ fn align_items_stretch() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/align_self_baseline.rs
+++ b/tests/generated/align_self_baseline.rs
@@ -12,7 +12,7 @@ fn align_self_baseline() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node10 = stretch
@@ -25,7 +25,7 @@ fn align_self_baseline() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -39,7 +39,7 @@ fn align_self_baseline() {
                 },
                 ..Default::default()
             },
-            vec![node10],
+            &[node10],
         )
         .unwrap();
     let node = stretch
@@ -52,7 +52,7 @@ fn align_self_baseline() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/align_self_center.rs
+++ b/tests/generated/align_self_center.rs
@@ -12,7 +12,7 @@ fn align_self_center() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -25,7 +25,7 @@ fn align_self_center() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/align_self_flex_end.rs
+++ b/tests/generated/align_self_flex_end.rs
@@ -12,7 +12,7 @@ fn align_self_flex_end() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -25,7 +25,7 @@ fn align_self_flex_end() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/align_self_flex_end_override_flex_start.rs
+++ b/tests/generated/align_self_flex_end_override_flex_start.rs
@@ -12,7 +12,7 @@ fn align_self_flex_end_override_flex_start() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -26,7 +26,7 @@ fn align_self_flex_end_override_flex_start() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/align_self_flex_start.rs
+++ b/tests/generated/align_self_flex_start.rs
@@ -12,7 +12,7 @@ fn align_self_flex_start() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -25,7 +25,7 @@ fn align_self_flex_start() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/align_strech_should_size_based_on_parent.rs
+++ b/tests/generated/align_strech_should_size_based_on_parent.rs
@@ -11,11 +11,11 @@ fn align_strech_should_size_based_on_parent() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node00 = stretch
-        .new_node(stretch::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, vec![node000])
+        .new_node(stretch::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[node000])
         .unwrap();
     let node0 = stretch
         .new_node(
@@ -25,7 +25,7 @@ fn align_strech_should_size_based_on_parent() {
                 flex_shrink: 1f32,
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node = stretch
@@ -38,7 +38,7 @@ fn align_strech_should_size_based_on_parent() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/border_center_child.rs
+++ b/tests/generated/border_center_child.rs
@@ -11,7 +11,7 @@ fn border_center_child() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -31,7 +31,7 @@ fn border_center_child() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/border_flex_child.rs
+++ b/tests/generated/border_flex_child.rs
@@ -8,7 +8,7 @@ fn border_flex_child() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -28,7 +28,7 @@ fn border_flex_child() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/border_no_child.rs
+++ b/tests/generated/border_no_child.rs
@@ -13,7 +13,7 @@ fn border_no_child() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/border_stretch_child.rs
+++ b/tests/generated/border_stretch_child.rs
@@ -7,7 +7,7 @@ fn border_stretch_child() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -27,7 +27,7 @@ fn border_stretch_child() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/child_min_max_width_flexing.rs
+++ b/tests/generated/child_min_max_width_flexing.rs
@@ -13,7 +13,7 @@ fn child_min_max_width_flexing() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -28,7 +28,7 @@ fn child_min_max_width_flexing() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -41,7 +41,7 @@ fn child_min_max_width_flexing() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/container_with_unsized_child.rs
+++ b/tests/generated/container_with_unsized_child.rs
@@ -1,7 +1,7 @@
 #[test]
 fn container_with_unsized_child() {
     let mut stretch = stretch::Stretch::new();
-    let node0 = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![]).unwrap();
+    let node0 = stretch.new_node(stretch::style::Style { ..Default::default() }, &[]).unwrap();
     let node = stretch
         .new_node(
             stretch::style::Style {
@@ -12,7 +12,7 @@ fn container_with_unsized_child() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/display_none.rs
+++ b/tests/generated/display_none.rs
@@ -1,11 +1,11 @@
 #[test]
 fn display_none() {
     let mut stretch = stretch::Stretch::new();
-    let node0 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
+    let node0 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node1 = stretch
         .new_node(
             stretch::style::Style { display: stretch::style::Display::None, flex_grow: 1f32, ..Default::default() },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -18,7 +18,7 @@ fn display_none() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/display_none_fixed_size.rs
+++ b/tests/generated/display_none_fixed_size.rs
@@ -1,7 +1,7 @@
 #[test]
 fn display_none_fixed_size() {
     let mut stretch = stretch::Stretch::new();
-    let node0 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
+    let node0 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node1 = stretch
         .new_node(
             stretch::style::Style {
@@ -13,7 +13,7 @@ fn display_none_fixed_size() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -26,7 +26,7 @@ fn display_none_fixed_size() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/display_none_with_child.rs
+++ b/tests/generated/display_none_with_child.rs
@@ -9,7 +9,7 @@ fn display_none_with_child() {
                 flex_basis: stretch::style::Dimension::Percent(0f32),
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node10 = stretch
@@ -21,7 +21,7 @@ fn display_none_with_child() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(20f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -34,7 +34,7 @@ fn display_none_with_child() {
                 flex_basis: stretch::style::Dimension::Percent(0f32),
                 ..Default::default()
             },
-            vec![node10],
+            &[node10],
         )
         .unwrap();
     let node2 = stretch
@@ -45,7 +45,7 @@ fn display_none_with_child() {
                 flex_basis: stretch::style::Dimension::Percent(0f32),
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -58,7 +58,7 @@ fn display_none_with_child() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/display_none_with_margin.rs
+++ b/tests/generated/display_none_with_margin.rs
@@ -19,10 +19,10 @@ fn display_none_with_margin() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
-    let node1 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
+    let node1 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node = stretch
         .new_node(
             stretch::style::Style {
@@ -33,7 +33,7 @@ fn display_none_with_margin() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/display_none_with_position.rs
+++ b/tests/generated/display_none_with_position.rs
@@ -1,7 +1,7 @@
 #[test]
 fn display_none_with_position() {
     let mut stretch = stretch::Stretch::new();
-    let node0 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
+    let node0 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node1 = stretch
         .new_node(
             stretch::style::Style {
@@ -13,7 +13,7 @@ fn display_none_with_position() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -26,7 +26,7 @@ fn display_none_with_position() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_basis_and_main_dimen_set_when_flexing.rs
+++ b/tests/generated/flex_basis_and_main_dimen_set_when_flexing.rs
@@ -13,7 +13,7 @@ fn flex_basis_and_main_dimen_set_when_flexing() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -28,7 +28,7 @@ fn flex_basis_and_main_dimen_set_when_flexing() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -40,7 +40,7 @@ fn flex_basis_and_main_dimen_set_when_flexing() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_basis_flex_grow_column.rs
+++ b/tests/generated/flex_basis_flex_grow_column.rs
@@ -8,10 +8,10 @@ fn flex_basis_flex_grow_column() {
                 flex_basis: stretch::style::Dimension::Points(50f32),
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
-    let node1 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
+    let node1 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node = stretch
         .new_node(
             stretch::style::Style {
@@ -23,7 +23,7 @@ fn flex_basis_flex_grow_column() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_basis_flex_grow_row.rs
+++ b/tests/generated/flex_basis_flex_grow_row.rs
@@ -8,10 +8,10 @@ fn flex_basis_flex_grow_row() {
                 flex_basis: stretch::style::Dimension::Points(50f32),
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
-    let node1 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
+    let node1 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node = stretch
         .new_node(
             stretch::style::Style {
@@ -22,7 +22,7 @@ fn flex_basis_flex_grow_row() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_basis_flex_shrink_column.rs
+++ b/tests/generated/flex_basis_flex_shrink_column.rs
@@ -4,13 +4,13 @@ fn flex_basis_flex_shrink_column() {
     let node0 = stretch
         .new_node(
             stretch::style::Style { flex_basis: stretch::style::Dimension::Points(100f32), ..Default::default() },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
         .new_node(
             stretch::style::Style { flex_basis: stretch::style::Dimension::Points(50f32), ..Default::default() },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -24,7 +24,7 @@ fn flex_basis_flex_shrink_column() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_basis_flex_shrink_row.rs
+++ b/tests/generated/flex_basis_flex_shrink_row.rs
@@ -4,13 +4,13 @@ fn flex_basis_flex_shrink_row() {
     let node0 = stretch
         .new_node(
             stretch::style::Style { flex_basis: stretch::style::Dimension::Points(100f32), ..Default::default() },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
         .new_node(
             stretch::style::Style { flex_basis: stretch::style::Dimension::Points(50f32), ..Default::default() },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -23,7 +23,7 @@ fn flex_basis_flex_shrink_row() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_basis_larger_than_content_column.rs
+++ b/tests/generated/flex_basis_larger_than_content_column.rs
@@ -11,7 +11,7 @@ fn flex_basis_larger_than_content_column() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -21,7 +21,7 @@ fn flex_basis_larger_than_content_column() {
                 flex_basis: stretch::style::Dimension::Points(50f32),
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node = stretch
@@ -34,7 +34,7 @@ fn flex_basis_larger_than_content_column() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_basis_larger_than_content_row.rs
+++ b/tests/generated/flex_basis_larger_than_content_row.rs
@@ -11,7 +11,7 @@ fn flex_basis_larger_than_content_row() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -21,7 +21,7 @@ fn flex_basis_larger_than_content_row() {
                 flex_basis: stretch::style::Dimension::Points(50f32),
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node = stretch
@@ -33,7 +33,7 @@ fn flex_basis_larger_than_content_row() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_basis_overrides_main_size.rs
+++ b/tests/generated/flex_basis_overrides_main_size.rs
@@ -9,7 +9,7 @@ fn flex_basis_overrides_main_size() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(20f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -19,7 +19,7 @@ fn flex_basis_overrides_main_size() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -29,7 +29,7 @@ fn flex_basis_overrides_main_size() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -42,7 +42,7 @@ fn flex_basis_overrides_main_size() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_basis_slightly_smaller_then_content_with_flex_grow_large_size.rs
+++ b/tests/generated/flex_basis_slightly_smaller_then_content_with_flex_grow_large_size.rs
@@ -11,7 +11,7 @@ fn flex_basis_slightly_smaller_then_content_with_flex_grow_large_size() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -22,7 +22,7 @@ fn flex_basis_slightly_smaller_then_content_with_flex_grow_large_size() {
                 flex_basis: stretch::style::Dimension::Points(60f32),
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node10 = stretch
@@ -35,7 +35,7 @@ fn flex_basis_slightly_smaller_then_content_with_flex_grow_large_size() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -46,7 +46,7 @@ fn flex_basis_slightly_smaller_then_content_with_flex_grow_large_size() {
                 flex_basis: stretch::style::Dimension::Points(0f32),
                 ..Default::default()
             },
-            vec![node10],
+            &[node10],
         )
         .unwrap();
     let node = stretch
@@ -58,7 +58,7 @@ fn flex_basis_slightly_smaller_then_content_with_flex_grow_large_size() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_basis_smaller_than_content_column.rs
+++ b/tests/generated/flex_basis_smaller_than_content_column.rs
@@ -11,7 +11,7 @@ fn flex_basis_smaller_than_content_column() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -21,7 +21,7 @@ fn flex_basis_smaller_than_content_column() {
                 flex_basis: stretch::style::Dimension::Points(50f32),
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node = stretch
@@ -34,7 +34,7 @@ fn flex_basis_smaller_than_content_column() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_basis_smaller_than_content_row.rs
+++ b/tests/generated/flex_basis_smaller_than_content_row.rs
@@ -11,7 +11,7 @@ fn flex_basis_smaller_than_content_row() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -21,7 +21,7 @@ fn flex_basis_smaller_than_content_row() {
                 flex_basis: stretch::style::Dimension::Points(50f32),
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node = stretch
@@ -33,7 +33,7 @@ fn flex_basis_smaller_than_content_row() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_basis_smaller_than_main_dimen_column.rs
+++ b/tests/generated/flex_basis_smaller_than_main_dimen_column.rs
@@ -12,7 +12,7 @@ fn flex_basis_smaller_than_main_dimen_column() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -25,7 +25,7 @@ fn flex_basis_smaller_than_main_dimen_column() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_basis_smaller_than_main_dimen_row.rs
+++ b/tests/generated/flex_basis_smaller_than_main_dimen_row.rs
@@ -12,7 +12,7 @@ fn flex_basis_smaller_than_main_dimen_row() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -24,7 +24,7 @@ fn flex_basis_smaller_than_main_dimen_row() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_basis_smaller_then_content_with_flex_grow_large_size.rs
+++ b/tests/generated/flex_basis_smaller_then_content_with_flex_grow_large_size.rs
@@ -11,7 +11,7 @@ fn flex_basis_smaller_then_content_with_flex_grow_large_size() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -22,7 +22,7 @@ fn flex_basis_smaller_then_content_with_flex_grow_large_size() {
                 flex_basis: stretch::style::Dimension::Points(0f32),
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node10 = stretch
@@ -35,7 +35,7 @@ fn flex_basis_smaller_then_content_with_flex_grow_large_size() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -46,7 +46,7 @@ fn flex_basis_smaller_then_content_with_flex_grow_large_size() {
                 flex_basis: stretch::style::Dimension::Points(0f32),
                 ..Default::default()
             },
-            vec![node10],
+            &[node10],
         )
         .unwrap();
     let node = stretch
@@ -58,7 +58,7 @@ fn flex_basis_smaller_then_content_with_flex_grow_large_size() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_basis_smaller_then_content_with_flex_grow_small_size.rs
+++ b/tests/generated/flex_basis_smaller_then_content_with_flex_grow_small_size.rs
@@ -11,7 +11,7 @@ fn flex_basis_smaller_then_content_with_flex_grow_small_size() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -22,7 +22,7 @@ fn flex_basis_smaller_then_content_with_flex_grow_small_size() {
                 flex_basis: stretch::style::Dimension::Points(0f32),
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node10 = stretch
@@ -35,7 +35,7 @@ fn flex_basis_smaller_then_content_with_flex_grow_small_size() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -46,7 +46,7 @@ fn flex_basis_smaller_then_content_with_flex_grow_small_size() {
                 flex_basis: stretch::style::Dimension::Points(0f32),
                 ..Default::default()
             },
-            vec![node10],
+            &[node10],
         )
         .unwrap();
     let node = stretch
@@ -55,7 +55,7 @@ fn flex_basis_smaller_then_content_with_flex_grow_small_size() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_basis_smaller_then_content_with_flex_grow_unconstraint_size.rs
+++ b/tests/generated/flex_basis_smaller_then_content_with_flex_grow_unconstraint_size.rs
@@ -11,7 +11,7 @@ fn flex_basis_smaller_then_content_with_flex_grow_unconstraint_size() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -22,7 +22,7 @@ fn flex_basis_smaller_then_content_with_flex_grow_unconstraint_size() {
                 flex_basis: stretch::style::Dimension::Points(0f32),
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node10 = stretch
@@ -35,7 +35,7 @@ fn flex_basis_smaller_then_content_with_flex_grow_unconstraint_size() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -46,10 +46,10 @@ fn flex_basis_smaller_then_content_with_flex_grow_unconstraint_size() {
                 flex_basis: stretch::style::Dimension::Points(0f32),
                 ..Default::default()
             },
-            vec![node10],
+            &[node10],
         )
         .unwrap();
-    let node = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node0, node1]).unwrap();
+    let node = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node0, node1]).unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();
     assert_eq!(stretch.layout(node).unwrap().size.width, 90f32);
     assert_eq!(stretch.layout(node).unwrap().size.height, 100f32);

--- a/tests/generated/flex_basis_smaller_then_content_with_flex_grow_very_large_size.rs
+++ b/tests/generated/flex_basis_smaller_then_content_with_flex_grow_very_large_size.rs
@@ -11,7 +11,7 @@ fn flex_basis_smaller_then_content_with_flex_grow_very_large_size() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -22,7 +22,7 @@ fn flex_basis_smaller_then_content_with_flex_grow_very_large_size() {
                 flex_basis: stretch::style::Dimension::Points(0f32),
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node10 = stretch
@@ -35,7 +35,7 @@ fn flex_basis_smaller_then_content_with_flex_grow_very_large_size() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -46,7 +46,7 @@ fn flex_basis_smaller_then_content_with_flex_grow_very_large_size() {
                 flex_basis: stretch::style::Dimension::Points(0f32),
                 ..Default::default()
             },
-            vec![node10],
+            &[node10],
         )
         .unwrap();
     let node = stretch
@@ -58,7 +58,7 @@ fn flex_basis_smaller_then_content_with_flex_grow_very_large_size() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_basis_unconstraint_column.rs
+++ b/tests/generated/flex_basis_unconstraint_column.rs
@@ -11,13 +11,13 @@ fn flex_basis_unconstraint_column() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
         .new_node(
             stretch::style::Style { flex_direction: stretch::style::FlexDirection::Column, ..Default::default() },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_basis_unconstraint_row.rs
+++ b/tests/generated/flex_basis_unconstraint_row.rs
@@ -11,10 +11,10 @@ fn flex_basis_unconstraint_row() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
-    let node = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node0]).unwrap();
+    let node = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node0]).unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();
     assert_eq!(stretch.layout(node).unwrap().size.width, 0f32);
     assert_eq!(stretch.layout(node).unwrap().size.height, 100f32);

--- a/tests/generated/flex_direction_column.rs
+++ b/tests/generated/flex_direction_column.rs
@@ -10,7 +10,7 @@ fn flex_direction_column() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -22,7 +22,7 @@ fn flex_direction_column() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -34,7 +34,7 @@ fn flex_direction_column() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -48,7 +48,7 @@ fn flex_direction_column() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_direction_column_no_height.rs
+++ b/tests/generated/flex_direction_column_no_height.rs
@@ -10,7 +10,7 @@ fn flex_direction_column_no_height() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -22,7 +22,7 @@ fn flex_direction_column_no_height() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -34,7 +34,7 @@ fn flex_direction_column_no_height() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -47,7 +47,7 @@ fn flex_direction_column_no_height() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_direction_column_reverse.rs
+++ b/tests/generated/flex_direction_column_reverse.rs
@@ -10,7 +10,7 @@ fn flex_direction_column_reverse() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -22,7 +22,7 @@ fn flex_direction_column_reverse() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -34,7 +34,7 @@ fn flex_direction_column_reverse() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -48,7 +48,7 @@ fn flex_direction_column_reverse() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_direction_row.rs
+++ b/tests/generated/flex_direction_row.rs
@@ -7,7 +7,7 @@ fn flex_direction_row() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -16,7 +16,7 @@ fn flex_direction_row() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -25,7 +25,7 @@ fn flex_direction_row() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -38,7 +38,7 @@ fn flex_direction_row() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_direction_row_no_width.rs
+++ b/tests/generated/flex_direction_row_no_width.rs
@@ -7,7 +7,7 @@ fn flex_direction_row_no_width() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -16,7 +16,7 @@ fn flex_direction_row_no_width() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -25,7 +25,7 @@ fn flex_direction_row_no_width() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -37,7 +37,7 @@ fn flex_direction_row_no_width() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_direction_row_reverse.rs
+++ b/tests/generated/flex_direction_row_reverse.rs
@@ -7,7 +7,7 @@ fn flex_direction_row_reverse() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -16,7 +16,7 @@ fn flex_direction_row_reverse() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -25,7 +25,7 @@ fn flex_direction_row_reverse() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -39,7 +39,7 @@ fn flex_direction_row_reverse() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_grow_child.rs
+++ b/tests/generated/flex_grow_child.rs
@@ -12,10 +12,10 @@ fn flex_grow_child() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
-    let node = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node0]).unwrap();
+    let node = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node0]).unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();
     assert_eq!(stretch.layout(node).unwrap().size.width, 0f32);
     assert_eq!(stretch.layout(node).unwrap().size.height, 100f32);

--- a/tests/generated/flex_grow_flex_basis_percent_min_max.rs
+++ b/tests/generated/flex_grow_flex_basis_percent_min_max.rs
@@ -17,7 +17,7 @@ fn flex_grow_flex_basis_percent_min_max() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -37,7 +37,7 @@ fn flex_grow_flex_basis_percent_min_max() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -49,7 +49,7 @@ fn flex_grow_flex_basis_percent_min_max() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_grow_height_maximized.rs
+++ b/tests/generated/flex_grow_height_maximized.rs
@@ -8,7 +8,7 @@ fn flex_grow_height_maximized() {
                 flex_basis: stretch::style::Dimension::Points(200f32),
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node01 = stretch
@@ -20,7 +20,7 @@ fn flex_grow_height_maximized() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -38,7 +38,7 @@ fn flex_grow_height_maximized() {
                 },
                 ..Default::default()
             },
-            vec![node00, node01],
+            &[node00, node01],
         )
         .unwrap();
     let node = stretch
@@ -52,7 +52,7 @@ fn flex_grow_height_maximized() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_grow_in_at_most_container.rs
+++ b/tests/generated/flex_grow_in_at_most_container.rs
@@ -8,10 +8,10 @@ fn flex_grow_in_at_most_container() {
                 flex_basis: stretch::style::Dimension::Points(0f32),
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
-    let node0 = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node00]).unwrap();
+    let node0 = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node00]).unwrap();
     let node = stretch
         .new_node(
             stretch::style::Style {
@@ -23,7 +23,7 @@ fn flex_grow_in_at_most_container() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_grow_less_than_factor_one.rs
+++ b/tests/generated/flex_grow_less_than_factor_one.rs
@@ -9,14 +9,14 @@ fn flex_grow_less_than_factor_one() {
                 flex_basis: stretch::style::Dimension::Points(40f32),
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
-        .new_node(stretch::style::Style { flex_grow: 0.2f32, flex_shrink: 0f32, ..Default::default() }, vec![])
+        .new_node(stretch::style::Style { flex_grow: 0.2f32, flex_shrink: 0f32, ..Default::default() }, &[])
         .unwrap();
     let node2 = stretch
-        .new_node(stretch::style::Style { flex_grow: 0.4f32, flex_shrink: 0f32, ..Default::default() }, vec![])
+        .new_node(stretch::style::Style { flex_grow: 0.4f32, flex_shrink: 0f32, ..Default::default() }, &[])
         .unwrap();
     let node = stretch
         .new_node(
@@ -28,7 +28,7 @@ fn flex_grow_less_than_factor_one() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_grow_root_minimized.rs
+++ b/tests/generated/flex_grow_root_minimized.rs
@@ -8,7 +8,7 @@ fn flex_grow_root_minimized() {
                 flex_basis: stretch::style::Dimension::Points(200f32),
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node01 = stretch
@@ -20,7 +20,7 @@ fn flex_grow_root_minimized() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -38,7 +38,7 @@ fn flex_grow_root_minimized() {
                 },
                 ..Default::default()
             },
-            vec![node00, node01],
+            &[node00, node01],
         )
         .unwrap();
     let node = stretch
@@ -59,7 +59,7 @@ fn flex_grow_root_minimized() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_grow_shrink_at_most.rs
+++ b/tests/generated/flex_grow_shrink_at_most.rs
@@ -2,9 +2,9 @@
 fn flex_grow_shrink_at_most() {
     let mut stretch = stretch::Stretch::new();
     let node00 = stretch
-        .new_node(stretch::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, vec![])
+        .new_node(stretch::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[])
         .unwrap();
-    let node0 = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node00]).unwrap();
+    let node0 = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node00]).unwrap();
     let node = stretch
         .new_node(
             stretch::style::Style {
@@ -15,7 +15,7 @@ fn flex_grow_shrink_at_most() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_grow_to_min.rs
+++ b/tests/generated/flex_grow_to_min.rs
@@ -2,7 +2,7 @@
 fn flex_grow_to_min() {
     let mut stretch = stretch::Stretch::new();
     let node0 = stretch
-        .new_node(stretch::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, vec![])
+        .new_node(stretch::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[])
         .unwrap();
     let node1 = stretch
         .new_node(
@@ -13,7 +13,7 @@ fn flex_grow_to_min() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -34,7 +34,7 @@ fn flex_grow_to_min() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_grow_within_constrained_max_column.rs
+++ b/tests/generated/flex_grow_within_constrained_max_column.rs
@@ -8,7 +8,7 @@ fn flex_grow_within_constrained_max_column() {
                 flex_basis: stretch::style::Dimension::Points(100f32),
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -20,7 +20,7 @@ fn flex_grow_within_constrained_max_column() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -37,7 +37,7 @@ fn flex_grow_within_constrained_max_column() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_grow_within_constrained_max_row.rs
+++ b/tests/generated/flex_grow_within_constrained_max_row.rs
@@ -8,7 +8,7 @@ fn flex_grow_within_constrained_max_row() {
                 flex_basis: stretch::style::Dimension::Points(100f32),
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node01 = stretch
@@ -17,7 +17,7 @@ fn flex_grow_within_constrained_max_row() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(50f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -33,7 +33,7 @@ fn flex_grow_within_constrained_max_row() {
                 },
                 ..Default::default()
             },
-            vec![node00, node01],
+            &[node00, node01],
         )
         .unwrap();
     let node = stretch
@@ -46,7 +46,7 @@ fn flex_grow_within_constrained_max_row() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_grow_within_constrained_max_width.rs
+++ b/tests/generated/flex_grow_within_constrained_max_width.rs
@@ -11,7 +11,7 @@ fn flex_grow_within_constrained_max_width() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -23,7 +23,7 @@ fn flex_grow_within_constrained_max_width() {
                 },
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node = stretch
@@ -37,7 +37,7 @@ fn flex_grow_within_constrained_max_width() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_grow_within_constrained_min_column.rs
+++ b/tests/generated/flex_grow_within_constrained_min_column.rs
@@ -1,7 +1,7 @@
 #[test]
 fn flex_grow_within_constrained_min_column() {
     let mut stretch = stretch::Stretch::new();
-    let node0 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
+    let node0 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node1 = stretch
         .new_node(
             stretch::style::Style {
@@ -11,7 +11,7 @@ fn flex_grow_within_constrained_min_column() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -24,7 +24,7 @@ fn flex_grow_within_constrained_min_column() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_grow_within_constrained_min_max_column.rs
+++ b/tests/generated/flex_grow_within_constrained_min_max_column.rs
@@ -1,7 +1,7 @@
 #[test]
 fn flex_grow_within_constrained_min_max_column() {
     let mut stretch = stretch::Stretch::new();
-    let node0 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
+    let node0 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node1 = stretch
         .new_node(
             stretch::style::Style {
@@ -11,7 +11,7 @@ fn flex_grow_within_constrained_min_max_column() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -23,7 +23,7 @@ fn flex_grow_within_constrained_min_max_column() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_grow_within_constrained_min_row.rs
+++ b/tests/generated/flex_grow_within_constrained_min_row.rs
@@ -1,14 +1,14 @@
 #[test]
 fn flex_grow_within_constrained_min_row() {
     let mut stretch = stretch::Stretch::new();
-    let node0 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
+    let node0 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node1 = stretch
         .new_node(
             stretch::style::Style {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(50f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -24,7 +24,7 @@ fn flex_grow_within_constrained_min_row() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_grow_within_max_width.rs
+++ b/tests/generated/flex_grow_within_max_width.rs
@@ -11,7 +11,7 @@ fn flex_grow_within_max_width() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -23,7 +23,7 @@ fn flex_grow_within_max_width() {
                 },
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node = stretch
@@ -37,7 +37,7 @@ fn flex_grow_within_max_width() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_root_ignored.rs
+++ b/tests/generated/flex_root_ignored.rs
@@ -8,7 +8,7 @@ fn flex_root_ignored() {
                 flex_basis: stretch::style::Dimension::Points(200f32),
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -20,7 +20,7 @@ fn flex_root_ignored() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -41,7 +41,7 @@ fn flex_root_ignored() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_shrink_by_outer_margin_with_max_size.rs
+++ b/tests/generated/flex_shrink_by_outer_margin_with_max_size.rs
@@ -15,7 +15,7 @@ fn flex_shrink_by_outer_margin_with_max_size() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -32,7 +32,7 @@ fn flex_shrink_by_outer_margin_with_max_size() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_shrink_flex_grow_child_flex_shrink_other_child.rs
+++ b/tests/generated/flex_shrink_flex_grow_child_flex_shrink_other_child.rs
@@ -13,7 +13,7 @@ fn flex_shrink_flex_grow_child_flex_shrink_other_child() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -28,7 +28,7 @@ fn flex_shrink_flex_grow_child_flex_shrink_other_child() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -41,7 +41,7 @@ fn flex_shrink_flex_grow_child_flex_shrink_other_child() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_shrink_flex_grow_row.rs
+++ b/tests/generated/flex_shrink_flex_grow_row.rs
@@ -13,7 +13,7 @@ fn flex_shrink_flex_grow_row() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -28,7 +28,7 @@ fn flex_shrink_flex_grow_row() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -41,7 +41,7 @@ fn flex_shrink_flex_grow_row() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_shrink_to_zero.rs
+++ b/tests/generated/flex_shrink_to_zero.rs
@@ -12,7 +12,7 @@ fn flex_shrink_to_zero() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -26,7 +26,7 @@ fn flex_shrink_to_zero() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -40,7 +40,7 @@ fn flex_shrink_to_zero() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -49,7 +49,7 @@ fn flex_shrink_to_zero() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(75f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_wrap_align_stretch_fits_one_row.rs
+++ b/tests/generated/flex_wrap_align_stretch_fits_one_row.rs
@@ -7,7 +7,7 @@ fn flex_wrap_align_stretch_fits_one_row() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(50f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -16,7 +16,7 @@ fn flex_wrap_align_stretch_fits_one_row() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(50f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -30,7 +30,7 @@ fn flex_wrap_align_stretch_fits_one_row() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_wrap_children_with_min_main_overriding_flex_basis.rs
+++ b/tests/generated/flex_wrap_children_with_min_main_overriding_flex_basis.rs
@@ -15,7 +15,7 @@ fn flex_wrap_children_with_min_main_overriding_flex_basis() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -32,7 +32,7 @@ fn flex_wrap_children_with_min_main_overriding_flex_basis() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -45,7 +45,7 @@ fn flex_wrap_children_with_min_main_overriding_flex_basis() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/flex_wrap_wrap_to_child_height.rs
+++ b/tests/generated/flex_wrap_wrap_to_child_height.rs
@@ -11,7 +11,7 @@ fn flex_wrap_wrap_to_child_height() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node00 = stretch
@@ -24,7 +24,7 @@ fn flex_wrap_wrap_to_child_height() {
                 },
                 ..Default::default()
             },
-            vec![node000],
+            &[node000],
         )
         .unwrap();
     let node0 = stretch
@@ -34,7 +34,7 @@ fn flex_wrap_wrap_to_child_height() {
                 align_items: stretch::style::AlignItems::FlexStart,
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node1 = stretch
@@ -47,13 +47,13 @@ fn flex_wrap_wrap_to_child_height() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
         .new_node(
             stretch::style::Style { flex_direction: stretch::style::FlexDirection::Column, ..Default::default() },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/justify_content_column_center.rs
+++ b/tests/generated/justify_content_column_center.rs
@@ -10,7 +10,7 @@ fn justify_content_column_center() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -22,7 +22,7 @@ fn justify_content_column_center() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -34,7 +34,7 @@ fn justify_content_column_center() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -49,7 +49,7 @@ fn justify_content_column_center() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/justify_content_column_flex_end.rs
+++ b/tests/generated/justify_content_column_flex_end.rs
@@ -10,7 +10,7 @@ fn justify_content_column_flex_end() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -22,7 +22,7 @@ fn justify_content_column_flex_end() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -34,7 +34,7 @@ fn justify_content_column_flex_end() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -49,7 +49,7 @@ fn justify_content_column_flex_end() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/justify_content_column_flex_start.rs
+++ b/tests/generated/justify_content_column_flex_start.rs
@@ -10,7 +10,7 @@ fn justify_content_column_flex_start() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -22,7 +22,7 @@ fn justify_content_column_flex_start() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -34,7 +34,7 @@ fn justify_content_column_flex_start() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -48,7 +48,7 @@ fn justify_content_column_flex_start() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/justify_content_column_min_height_and_margin_bottom.rs
+++ b/tests/generated/justify_content_column_min_height_and_margin_bottom.rs
@@ -15,7 +15,7 @@ fn justify_content_column_min_height_and_margin_bottom() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -29,7 +29,7 @@ fn justify_content_column_min_height_and_margin_bottom() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/justify_content_column_min_height_and_margin_top.rs
+++ b/tests/generated/justify_content_column_min_height_and_margin_top.rs
@@ -12,7 +12,7 @@ fn justify_content_column_min_height_and_margin_top() {
                 margin: stretch::geometry::Rect { top: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -26,7 +26,7 @@ fn justify_content_column_min_height_and_margin_top() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/justify_content_column_space_around.rs
+++ b/tests/generated/justify_content_column_space_around.rs
@@ -10,7 +10,7 @@ fn justify_content_column_space_around() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -22,7 +22,7 @@ fn justify_content_column_space_around() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -34,7 +34,7 @@ fn justify_content_column_space_around() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -49,7 +49,7 @@ fn justify_content_column_space_around() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/justify_content_column_space_between.rs
+++ b/tests/generated/justify_content_column_space_between.rs
@@ -10,7 +10,7 @@ fn justify_content_column_space_between() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -22,7 +22,7 @@ fn justify_content_column_space_between() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -34,7 +34,7 @@ fn justify_content_column_space_between() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -49,7 +49,7 @@ fn justify_content_column_space_between() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/justify_content_column_space_evenly.rs
+++ b/tests/generated/justify_content_column_space_evenly.rs
@@ -10,7 +10,7 @@ fn justify_content_column_space_evenly() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -22,7 +22,7 @@ fn justify_content_column_space_evenly() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -34,7 +34,7 @@ fn justify_content_column_space_evenly() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -49,7 +49,7 @@ fn justify_content_column_space_evenly() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/justify_content_min_max.rs
+++ b/tests/generated/justify_content_min_max.rs
@@ -11,7 +11,7 @@ fn justify_content_min_max() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -33,7 +33,7 @@ fn justify_content_min_max() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/justify_content_min_width_with_padding_child_width_greater_than_parent.rs
+++ b/tests/generated/justify_content_min_width_with_padding_child_width_greater_than_parent.rs
@@ -11,7 +11,7 @@ fn justify_content_min_width_with_padding_child_width_greater_than_parent() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node00 = stretch
@@ -29,10 +29,10 @@ fn justify_content_min_width_with_padding_child_width_greater_than_parent() {
                 },
                 ..Default::default()
             },
-            vec![node000],
+            &[node000],
         )
         .unwrap();
-    let node0 = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node00]).unwrap();
+    let node0 = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node00]).unwrap();
     let node = stretch
         .new_node(
             stretch::style::Style {
@@ -44,7 +44,7 @@ fn justify_content_min_width_with_padding_child_width_greater_than_parent() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/justify_content_min_width_with_padding_child_width_lower_than_parent.rs
+++ b/tests/generated/justify_content_min_width_with_padding_child_width_lower_than_parent.rs
@@ -11,7 +11,7 @@ fn justify_content_min_width_with_padding_child_width_lower_than_parent() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node00 = stretch
@@ -29,10 +29,10 @@ fn justify_content_min_width_with_padding_child_width_lower_than_parent() {
                 },
                 ..Default::default()
             },
-            vec![node000],
+            &[node000],
         )
         .unwrap();
-    let node0 = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node00]).unwrap();
+    let node0 = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node00]).unwrap();
     let node = stretch
         .new_node(
             stretch::style::Style {
@@ -44,7 +44,7 @@ fn justify_content_min_width_with_padding_child_width_lower_than_parent() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/justify_content_overflow_min_max.rs
+++ b/tests/generated/justify_content_overflow_min_max.rs
@@ -12,7 +12,7 @@ fn justify_content_overflow_min_max() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -26,7 +26,7 @@ fn justify_content_overflow_min_max() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -40,7 +40,7 @@ fn justify_content_overflow_min_max() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -58,7 +58,7 @@ fn justify_content_overflow_min_max() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/justify_content_row_center.rs
+++ b/tests/generated/justify_content_row_center.rs
@@ -7,7 +7,7 @@ fn justify_content_row_center() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -16,7 +16,7 @@ fn justify_content_row_center() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -25,7 +25,7 @@ fn justify_content_row_center() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -39,7 +39,7 @@ fn justify_content_row_center() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/justify_content_row_flex_end.rs
+++ b/tests/generated/justify_content_row_flex_end.rs
@@ -7,7 +7,7 @@ fn justify_content_row_flex_end() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -16,7 +16,7 @@ fn justify_content_row_flex_end() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -25,7 +25,7 @@ fn justify_content_row_flex_end() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -39,7 +39,7 @@ fn justify_content_row_flex_end() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/justify_content_row_flex_start.rs
+++ b/tests/generated/justify_content_row_flex_start.rs
@@ -7,7 +7,7 @@ fn justify_content_row_flex_start() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -16,7 +16,7 @@ fn justify_content_row_flex_start() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -25,7 +25,7 @@ fn justify_content_row_flex_start() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -38,7 +38,7 @@ fn justify_content_row_flex_start() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/justify_content_row_max_width_and_margin.rs
+++ b/tests/generated/justify_content_row_max_width_and_margin.rs
@@ -15,7 +15,7 @@ fn justify_content_row_max_width_and_margin() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -32,7 +32,7 @@ fn justify_content_row_max_width_and_margin() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/justify_content_row_min_width_and_margin.rs
+++ b/tests/generated/justify_content_row_min_width_and_margin.rs
@@ -15,7 +15,7 @@ fn justify_content_row_min_width_and_margin() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -28,7 +28,7 @@ fn justify_content_row_min_width_and_margin() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/justify_content_row_space_around.rs
+++ b/tests/generated/justify_content_row_space_around.rs
@@ -7,7 +7,7 @@ fn justify_content_row_space_around() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -16,7 +16,7 @@ fn justify_content_row_space_around() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -25,7 +25,7 @@ fn justify_content_row_space_around() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -39,7 +39,7 @@ fn justify_content_row_space_around() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/justify_content_row_space_between.rs
+++ b/tests/generated/justify_content_row_space_between.rs
@@ -7,7 +7,7 @@ fn justify_content_row_space_between() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -16,7 +16,7 @@ fn justify_content_row_space_between() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -25,7 +25,7 @@ fn justify_content_row_space_between() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -39,7 +39,7 @@ fn justify_content_row_space_between() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/justify_content_row_space_evenly.rs
+++ b/tests/generated/justify_content_row_space_evenly.rs
@@ -10,7 +10,7 @@ fn justify_content_row_space_evenly() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -22,7 +22,7 @@ fn justify_content_row_space_evenly() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -34,7 +34,7 @@ fn justify_content_row_space_evenly() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -48,7 +48,7 @@ fn justify_content_row_space_evenly() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/margin_and_flex_column.rs
+++ b/tests/generated/margin_and_flex_column.rs
@@ -12,7 +12,7 @@ fn margin_and_flex_column() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -26,7 +26,7 @@ fn margin_and_flex_column() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/margin_and_flex_row.rs
+++ b/tests/generated/margin_and_flex_row.rs
@@ -12,7 +12,7 @@ fn margin_and_flex_row() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -25,7 +25,7 @@ fn margin_and_flex_row() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/margin_and_stretch_column.rs
+++ b/tests/generated/margin_and_stretch_column.rs
@@ -12,7 +12,7 @@ fn margin_and_stretch_column() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -26,7 +26,7 @@ fn margin_and_stretch_column() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/margin_and_stretch_row.rs
+++ b/tests/generated/margin_and_stretch_row.rs
@@ -12,7 +12,7 @@ fn margin_and_stretch_row() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -25,7 +25,7 @@ fn margin_and_stretch_row() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/margin_auto_bottom.rs
+++ b/tests/generated/margin_auto_bottom.rs
@@ -12,7 +12,7 @@ fn margin_auto_bottom() {
                 margin: stretch::geometry::Rect { bottom: stretch::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -25,7 +25,7 @@ fn margin_auto_bottom() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -39,7 +39,7 @@ fn margin_auto_bottom() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/margin_auto_bottom_and_top.rs
+++ b/tests/generated/margin_auto_bottom_and_top.rs
@@ -16,7 +16,7 @@ fn margin_auto_bottom_and_top() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -29,7 +29,7 @@ fn margin_auto_bottom_and_top() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -43,7 +43,7 @@ fn margin_auto_bottom_and_top() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/margin_auto_bottom_and_top_justify_center.rs
+++ b/tests/generated/margin_auto_bottom_and_top_justify_center.rs
@@ -16,7 +16,7 @@ fn margin_auto_bottom_and_top_justify_center() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -29,7 +29,7 @@ fn margin_auto_bottom_and_top_justify_center() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -43,7 +43,7 @@ fn margin_auto_bottom_and_top_justify_center() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/margin_auto_left.rs
+++ b/tests/generated/margin_auto_left.rs
@@ -12,7 +12,7 @@ fn margin_auto_left() {
                 margin: stretch::geometry::Rect { start: stretch::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -25,7 +25,7 @@ fn margin_auto_left() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -39,7 +39,7 @@ fn margin_auto_left() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/margin_auto_left_and_right.rs
+++ b/tests/generated/margin_auto_left_and_right.rs
@@ -16,7 +16,7 @@ fn margin_auto_left_and_right() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -29,7 +29,7 @@ fn margin_auto_left_and_right() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -42,7 +42,7 @@ fn margin_auto_left_and_right() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/margin_auto_left_and_right_column.rs
+++ b/tests/generated/margin_auto_left_and_right_column.rs
@@ -16,7 +16,7 @@ fn margin_auto_left_and_right_column() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -29,7 +29,7 @@ fn margin_auto_left_and_right_column() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -43,7 +43,7 @@ fn margin_auto_left_and_right_column() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/margin_auto_left_and_right_column_and_center.rs
+++ b/tests/generated/margin_auto_left_and_right_column_and_center.rs
@@ -16,7 +16,7 @@ fn margin_auto_left_and_right_column_and_center() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -29,7 +29,7 @@ fn margin_auto_left_and_right_column_and_center() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -43,7 +43,7 @@ fn margin_auto_left_and_right_column_and_center() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/margin_auto_left_and_right_strech.rs
+++ b/tests/generated/margin_auto_left_and_right_strech.rs
@@ -16,7 +16,7 @@ fn margin_auto_left_and_right_strech() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -29,7 +29,7 @@ fn margin_auto_left_and_right_strech() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -42,7 +42,7 @@ fn margin_auto_left_and_right_strech() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/margin_auto_left_child_bigger_than_parent.rs
+++ b/tests/generated/margin_auto_left_child_bigger_than_parent.rs
@@ -12,7 +12,7 @@ fn margin_auto_left_child_bigger_than_parent() {
                 margin: stretch::geometry::Rect { start: stretch::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -26,7 +26,7 @@ fn margin_auto_left_child_bigger_than_parent() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/margin_auto_left_fix_right_child_bigger_than_parent.rs
+++ b/tests/generated/margin_auto_left_fix_right_child_bigger_than_parent.rs
@@ -16,7 +16,7 @@ fn margin_auto_left_fix_right_child_bigger_than_parent() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -30,7 +30,7 @@ fn margin_auto_left_fix_right_child_bigger_than_parent() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/margin_auto_left_right_child_bigger_than_parent.rs
+++ b/tests/generated/margin_auto_left_right_child_bigger_than_parent.rs
@@ -16,7 +16,7 @@ fn margin_auto_left_right_child_bigger_than_parent() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -30,7 +30,7 @@ fn margin_auto_left_right_child_bigger_than_parent() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/margin_auto_left_stretching_child.rs
+++ b/tests/generated/margin_auto_left_stretching_child.rs
@@ -10,7 +10,7 @@ fn margin_auto_left_stretching_child() {
                 margin: stretch::geometry::Rect { start: stretch::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -23,7 +23,7 @@ fn margin_auto_left_stretching_child() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -37,7 +37,7 @@ fn margin_auto_left_stretching_child() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/margin_auto_mutiple_children_column.rs
+++ b/tests/generated/margin_auto_mutiple_children_column.rs
@@ -12,7 +12,7 @@ fn margin_auto_mutiple_children_column() {
                 margin: stretch::geometry::Rect { top: stretch::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -26,7 +26,7 @@ fn margin_auto_mutiple_children_column() {
                 margin: stretch::geometry::Rect { top: stretch::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -39,7 +39,7 @@ fn margin_auto_mutiple_children_column() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -54,7 +54,7 @@ fn margin_auto_mutiple_children_column() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/margin_auto_mutiple_children_row.rs
+++ b/tests/generated/margin_auto_mutiple_children_row.rs
@@ -12,7 +12,7 @@ fn margin_auto_mutiple_children_row() {
                 margin: stretch::geometry::Rect { end: stretch::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -26,7 +26,7 @@ fn margin_auto_mutiple_children_row() {
                 margin: stretch::geometry::Rect { end: stretch::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -39,7 +39,7 @@ fn margin_auto_mutiple_children_row() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -53,7 +53,7 @@ fn margin_auto_mutiple_children_row() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/margin_auto_right.rs
+++ b/tests/generated/margin_auto_right.rs
@@ -12,7 +12,7 @@ fn margin_auto_right() {
                 margin: stretch::geometry::Rect { end: stretch::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -25,7 +25,7 @@ fn margin_auto_right() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -39,7 +39,7 @@ fn margin_auto_right() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/margin_auto_top.rs
+++ b/tests/generated/margin_auto_top.rs
@@ -12,7 +12,7 @@ fn margin_auto_top() {
                 margin: stretch::geometry::Rect { top: stretch::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -25,7 +25,7 @@ fn margin_auto_top() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -39,7 +39,7 @@ fn margin_auto_top() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/margin_auto_top_and_bottom_strech.rs
+++ b/tests/generated/margin_auto_top_and_bottom_strech.rs
@@ -16,7 +16,7 @@ fn margin_auto_top_and_bottom_strech() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -29,7 +29,7 @@ fn margin_auto_top_and_bottom_strech() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -43,7 +43,7 @@ fn margin_auto_top_and_bottom_strech() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/margin_auto_top_stretching_child.rs
+++ b/tests/generated/margin_auto_top_stretching_child.rs
@@ -10,7 +10,7 @@ fn margin_auto_top_stretching_child() {
                 margin: stretch::geometry::Rect { top: stretch::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -23,7 +23,7 @@ fn margin_auto_top_stretching_child() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -37,7 +37,7 @@ fn margin_auto_top_stretching_child() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/margin_bottom.rs
+++ b/tests/generated/margin_bottom.rs
@@ -14,7 +14,7 @@ fn margin_bottom() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -29,7 +29,7 @@ fn margin_bottom() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/margin_fix_left_auto_right_child_bigger_than_parent.rs
+++ b/tests/generated/margin_fix_left_auto_right_child_bigger_than_parent.rs
@@ -16,7 +16,7 @@ fn margin_fix_left_auto_right_child_bigger_than_parent() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -30,7 +30,7 @@ fn margin_fix_left_auto_right_child_bigger_than_parent() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/margin_left.rs
+++ b/tests/generated/margin_left.rs
@@ -11,7 +11,7 @@ fn margin_left() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -24,7 +24,7 @@ fn margin_left() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/margin_right.rs
+++ b/tests/generated/margin_right.rs
@@ -8,7 +8,7 @@ fn margin_right() {
                 margin: stretch::geometry::Rect { end: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -22,7 +22,7 @@ fn margin_right() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/margin_should_not_be_part_of_max_height.rs
+++ b/tests/generated/margin_should_not_be_part_of_max_height.rs
@@ -16,7 +16,7 @@ fn margin_should_not_be_part_of_max_height() {
                 margin: stretch::geometry::Rect { top: stretch::style::Dimension::Points(20f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -29,7 +29,7 @@ fn margin_should_not_be_part_of_max_height() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/margin_should_not_be_part_of_max_width.rs
+++ b/tests/generated/margin_should_not_be_part_of_max_width.rs
@@ -19,7 +19,7 @@ fn margin_should_not_be_part_of_max_width() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -32,7 +32,7 @@ fn margin_should_not_be_part_of_max_width() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/margin_top.rs
+++ b/tests/generated/margin_top.rs
@@ -11,7 +11,7 @@ fn margin_top() {
                 margin: stretch::geometry::Rect { top: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -25,7 +25,7 @@ fn margin_top() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/margin_with_sibling_column.rs
+++ b/tests/generated/margin_with_sibling_column.rs
@@ -11,10 +11,10 @@ fn margin_with_sibling_column() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
-    let node1 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
+    let node1 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node = stretch
         .new_node(
             stretch::style::Style {
@@ -26,7 +26,7 @@ fn margin_with_sibling_column() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/margin_with_sibling_row.rs
+++ b/tests/generated/margin_with_sibling_row.rs
@@ -8,10 +8,10 @@ fn margin_with_sibling_row() {
                 margin: stretch::geometry::Rect { end: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
-    let node1 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
+    let node1 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node = stretch
         .new_node(
             stretch::style::Style {
@@ -22,7 +22,7 @@ fn margin_with_sibling_row() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/max_height.rs
+++ b/tests/generated/max_height.rs
@@ -11,7 +11,7 @@ fn max_height() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -24,7 +24,7 @@ fn max_height() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/max_height_overrides_height.rs
+++ b/tests/generated/max_height_overrides_height.rs
@@ -14,10 +14,10 @@ fn max_height_overrides_height() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
-    let node = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node0]).unwrap();
+    let node = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node0]).unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();
     assert_eq!(stretch.layout(node).unwrap().size.width, 0f32);
     assert_eq!(stretch.layout(node).unwrap().size.height, 100f32);

--- a/tests/generated/max_height_overrides_height_on_root.rs
+++ b/tests/generated/max_height_overrides_height_on_root.rs
@@ -14,7 +14,7 @@ fn max_height_overrides_height_on_root() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/max_width.rs
+++ b/tests/generated/max_width.rs
@@ -14,7 +14,7 @@ fn max_width() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -28,7 +28,7 @@ fn max_width() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/max_width_overrides_width.rs
+++ b/tests/generated/max_width_overrides_width.rs
@@ -14,10 +14,10 @@ fn max_width_overrides_width() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
-    let node = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node0]).unwrap();
+    let node = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node0]).unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();
     assert_eq!(stretch.layout(node).unwrap().size.width, 100f32);
     assert_eq!(stretch.layout(node).unwrap().size.height, 0f32);

--- a/tests/generated/max_width_overrides_width_on_root.rs
+++ b/tests/generated/max_width_overrides_width_on_root.rs
@@ -14,7 +14,7 @@ fn max_width_overrides_width_on_root() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/min_height.rs
+++ b/tests/generated/min_height.rs
@@ -11,10 +11,10 @@ fn min_height() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
-    let node1 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
+    let node1 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node = stretch
         .new_node(
             stretch::style::Style {
@@ -26,7 +26,7 @@ fn min_height() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/min_height_overrides_height.rs
+++ b/tests/generated/min_height_overrides_height.rs
@@ -14,10 +14,10 @@ fn min_height_overrides_height() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
-    let node = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node0]).unwrap();
+    let node = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node0]).unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();
     assert_eq!(stretch.layout(node).unwrap().size.width, 0f32);
     assert_eq!(stretch.layout(node).unwrap().size.height, 100f32);

--- a/tests/generated/min_height_overrides_height_on_root.rs
+++ b/tests/generated/min_height_overrides_height_on_root.rs
@@ -14,7 +14,7 @@ fn min_height_overrides_height_on_root() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/min_max_percent_no_width_height.rs
+++ b/tests/generated/min_max_percent_no_width_height.rs
@@ -16,7 +16,7 @@ fn min_max_percent_no_width_height() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -31,7 +31,7 @@ fn min_max_percent_no_width_height() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/min_width.rs
+++ b/tests/generated/min_width.rs
@@ -11,10 +11,10 @@ fn min_width() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
-    let node1 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
+    let node1 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node = stretch
         .new_node(
             stretch::style::Style {
@@ -25,7 +25,7 @@ fn min_width() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/min_width_overrides_width.rs
+++ b/tests/generated/min_width_overrides_width.rs
@@ -11,10 +11,10 @@ fn min_width_overrides_width() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
-    let node = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node0]).unwrap();
+    let node = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node0]).unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();
     assert_eq!(stretch.layout(node).unwrap().size.width, 100f32);
     assert_eq!(stretch.layout(node).unwrap().size.height, 0f32);

--- a/tests/generated/min_width_overrides_width_on_root.rs
+++ b/tests/generated/min_width_overrides_width_on_root.rs
@@ -11,7 +11,7 @@ fn min_width_overrides_width_on_root() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/nested_overflowing_child.rs
+++ b/tests/generated/nested_overflowing_child.rs
@@ -11,10 +11,10 @@ fn nested_overflowing_child() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
-    let node0 = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node00]).unwrap();
+    let node0 = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node00]).unwrap();
     let node = stretch
         .new_node(
             stretch::style::Style {
@@ -25,7 +25,7 @@ fn nested_overflowing_child() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/nested_overflowing_child_in_constraint_parent.rs
+++ b/tests/generated/nested_overflowing_child_in_constraint_parent.rs
@@ -11,7 +11,7 @@ fn nested_overflowing_child_in_constraint_parent() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -24,7 +24,7 @@ fn nested_overflowing_child_in_constraint_parent() {
                 },
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node = stretch
@@ -37,7 +37,7 @@ fn nested_overflowing_child_in_constraint_parent() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/overflow_cross_axis.rs
+++ b/tests/generated/overflow_cross_axis.rs
@@ -11,7 +11,7 @@ fn overflow_cross_axis() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -24,7 +24,7 @@ fn overflow_cross_axis() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/overflow_main_axis.rs
+++ b/tests/generated/overflow_main_axis.rs
@@ -11,7 +11,7 @@ fn overflow_main_axis() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -24,7 +24,7 @@ fn overflow_main_axis() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/padding_align_end_child.rs
+++ b/tests/generated/padding_align_end_child.rs
@@ -18,7 +18,7 @@ fn padding_align_end_child() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -33,7 +33,7 @@ fn padding_align_end_child() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/padding_center_child.rs
+++ b/tests/generated/padding_center_child.rs
@@ -11,7 +11,7 @@ fn padding_center_child() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -33,7 +33,7 @@ fn padding_center_child() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/padding_flex_child.rs
+++ b/tests/generated/padding_flex_child.rs
@@ -8,7 +8,7 @@ fn padding_flex_child() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -28,7 +28,7 @@ fn padding_flex_child() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/padding_no_child.rs
+++ b/tests/generated/padding_no_child.rs
@@ -13,7 +13,7 @@ fn padding_no_child() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/padding_stretch_child.rs
+++ b/tests/generated/padding_stretch_child.rs
@@ -10,7 +10,7 @@ fn padding_stretch_child() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -30,7 +30,7 @@ fn padding_stretch_child() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/parent_wrap_child_size_overflowing_parent.rs
+++ b/tests/generated/parent_wrap_child_size_overflowing_parent.rs
@@ -11,7 +11,7 @@ fn parent_wrap_child_size_overflowing_parent() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -23,7 +23,7 @@ fn parent_wrap_child_size_overflowing_parent() {
                 },
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node = stretch
@@ -36,7 +36,7 @@ fn parent_wrap_child_size_overflowing_parent() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/percent_absolute_position.rs
+++ b/tests/generated/percent_absolute_position.rs
@@ -7,7 +7,7 @@ fn percent_absolute_position() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Percent(1f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node01 = stretch
@@ -16,7 +16,7 @@ fn percent_absolute_position() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Percent(1f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -34,7 +34,7 @@ fn percent_absolute_position() {
                 },
                 ..Default::default()
             },
-            vec![node00, node01],
+            &[node00, node01],
         )
         .unwrap();
     let node = stretch
@@ -48,7 +48,7 @@ fn percent_absolute_position() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/percent_within_flex_grow.rs
+++ b/tests/generated/percent_within_flex_grow.rs
@@ -10,7 +10,7 @@ fn percent_within_flex_grow() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node10 = stretch
@@ -19,7 +19,7 @@ fn percent_within_flex_grow() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Percent(1f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -29,7 +29,7 @@ fn percent_within_flex_grow() {
                 flex_grow: 1f32,
                 ..Default::default()
             },
-            vec![node10],
+            &[node10],
         )
         .unwrap();
     let node2 = stretch
@@ -41,7 +41,7 @@ fn percent_within_flex_grow() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -54,7 +54,7 @@ fn percent_within_flex_grow() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/percentage_absolute_position.rs
+++ b/tests/generated/percentage_absolute_position.rs
@@ -17,7 +17,7 @@ fn percentage_absolute_position() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -31,7 +31,7 @@ fn percentage_absolute_position() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/percentage_container_in_wrapping_container.rs
+++ b/tests/generated/percentage_container_in_wrapping_container.rs
@@ -11,7 +11,7 @@ fn percentage_container_in_wrapping_container() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node001 = stretch
@@ -24,7 +24,7 @@ fn percentage_container_in_wrapping_container() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node00 = stretch
@@ -34,13 +34,13 @@ fn percentage_container_in_wrapping_container() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Percent(1f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![node000, node001],
+            &[node000, node001],
         )
         .unwrap();
     let node0 = stretch
         .new_node(
             stretch::style::Style { flex_direction: stretch::style::FlexDirection::Column, ..Default::default() },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node = stretch
@@ -56,7 +56,7 @@ fn percentage_container_in_wrapping_container() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/percentage_flex_basis.rs
+++ b/tests/generated/percentage_flex_basis.rs
@@ -8,7 +8,7 @@ fn percentage_flex_basis() {
                 flex_basis: stretch::style::Dimension::Percent(0.5f32),
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -18,7 +18,7 @@ fn percentage_flex_basis() {
                 flex_basis: stretch::style::Dimension::Percent(0.25f32),
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -31,7 +31,7 @@ fn percentage_flex_basis() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/percentage_flex_basis_cross.rs
+++ b/tests/generated/percentage_flex_basis_cross.rs
@@ -8,7 +8,7 @@ fn percentage_flex_basis_cross() {
                 flex_basis: stretch::style::Dimension::Percent(0.5f32),
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -18,7 +18,7 @@ fn percentage_flex_basis_cross() {
                 flex_basis: stretch::style::Dimension::Percent(0.25f32),
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -32,7 +32,7 @@ fn percentage_flex_basis_cross() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/percentage_flex_basis_cross_max_height.rs
+++ b/tests/generated/percentage_flex_basis_cross_max_height.rs
@@ -12,7 +12,7 @@ fn percentage_flex_basis_cross_max_height() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -26,7 +26,7 @@ fn percentage_flex_basis_cross_max_height() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -40,7 +40,7 @@ fn percentage_flex_basis_cross_max_height() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/percentage_flex_basis_cross_max_width.rs
+++ b/tests/generated/percentage_flex_basis_cross_max_width.rs
@@ -12,7 +12,7 @@ fn percentage_flex_basis_cross_max_width() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -26,7 +26,7 @@ fn percentage_flex_basis_cross_max_width() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -40,7 +40,7 @@ fn percentage_flex_basis_cross_max_width() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/percentage_flex_basis_cross_min_height.rs
+++ b/tests/generated/percentage_flex_basis_cross_min_height.rs
@@ -11,7 +11,7 @@ fn percentage_flex_basis_cross_min_height() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -24,7 +24,7 @@ fn percentage_flex_basis_cross_min_height() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -38,7 +38,7 @@ fn percentage_flex_basis_cross_min_height() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/percentage_flex_basis_cross_min_width.rs
+++ b/tests/generated/percentage_flex_basis_cross_min_width.rs
@@ -12,7 +12,7 @@ fn percentage_flex_basis_cross_min_width() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -26,7 +26,7 @@ fn percentage_flex_basis_cross_min_width() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -40,7 +40,7 @@ fn percentage_flex_basis_cross_min_width() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/percentage_flex_basis_main_max_height.rs
+++ b/tests/generated/percentage_flex_basis_main_max_height.rs
@@ -12,7 +12,7 @@ fn percentage_flex_basis_main_max_height() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -26,7 +26,7 @@ fn percentage_flex_basis_main_max_height() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -39,7 +39,7 @@ fn percentage_flex_basis_main_max_height() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/percentage_flex_basis_main_max_width.rs
+++ b/tests/generated/percentage_flex_basis_main_max_width.rs
@@ -12,7 +12,7 @@ fn percentage_flex_basis_main_max_width() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -26,7 +26,7 @@ fn percentage_flex_basis_main_max_width() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -39,7 +39,7 @@ fn percentage_flex_basis_main_max_width() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/percentage_flex_basis_main_min_width.rs
+++ b/tests/generated/percentage_flex_basis_main_min_width.rs
@@ -12,7 +12,7 @@ fn percentage_flex_basis_main_min_width() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -26,7 +26,7 @@ fn percentage_flex_basis_main_min_width() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -39,7 +39,7 @@ fn percentage_flex_basis_main_min_width() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/percentage_margin_should_calculate_based_only_on_width.rs
+++ b/tests/generated/percentage_margin_should_calculate_based_only_on_width.rs
@@ -11,7 +11,7 @@ fn percentage_margin_should_calculate_based_only_on_width() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -28,7 +28,7 @@ fn percentage_margin_should_calculate_based_only_on_width() {
                 },
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node = stretch
@@ -42,7 +42,7 @@ fn percentage_margin_should_calculate_based_only_on_width() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/percentage_multiple_nested_with_padding_margin_and_percentage_values.rs
+++ b/tests/generated/percentage_multiple_nested_with_padding_margin_and_percentage_values.rs
@@ -24,7 +24,7 @@ fn percentage_multiple_nested_with_padding_margin_and_percentage_values() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node00 = stretch
@@ -51,7 +51,7 @@ fn percentage_multiple_nested_with_padding_margin_and_percentage_values() {
                 },
                 ..Default::default()
             },
-            vec![node000],
+            &[node000],
         )
         .unwrap();
     let node0 = stretch
@@ -80,7 +80,7 @@ fn percentage_multiple_nested_with_padding_margin_and_percentage_values() {
                 },
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node1 = stretch
@@ -94,7 +94,7 @@ fn percentage_multiple_nested_with_padding_margin_and_percentage_values() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -108,7 +108,7 @@ fn percentage_multiple_nested_with_padding_margin_and_percentage_values() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/percentage_padding_should_calculate_based_only_on_width.rs
+++ b/tests/generated/percentage_padding_should_calculate_based_only_on_width.rs
@@ -11,7 +11,7 @@ fn percentage_padding_should_calculate_based_only_on_width() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -28,7 +28,7 @@ fn percentage_padding_should_calculate_based_only_on_width() {
                 },
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node = stretch
@@ -42,7 +42,7 @@ fn percentage_padding_should_calculate_based_only_on_width() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/percentage_position_bottom_right.rs
+++ b/tests/generated/percentage_position_bottom_right.rs
@@ -16,7 +16,7 @@ fn percentage_position_bottom_right() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -29,7 +29,7 @@ fn percentage_position_bottom_right() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/percentage_position_left_top.rs
+++ b/tests/generated/percentage_position_left_top.rs
@@ -16,7 +16,7 @@ fn percentage_position_left_top() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -29,7 +29,7 @@ fn percentage_position_left_top() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/percentage_size_based_on_parent_inner_size.rs
+++ b/tests/generated/percentage_size_based_on_parent_inner_size.rs
@@ -11,7 +11,7 @@ fn percentage_size_based_on_parent_inner_size() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -32,7 +32,7 @@ fn percentage_size_based_on_parent_inner_size() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/percentage_size_of_flex_basis.rs
+++ b/tests/generated/percentage_size_of_flex_basis.rs
@@ -11,13 +11,13 @@ fn percentage_size_of_flex_basis() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
         .new_node(
             stretch::style::Style { flex_basis: stretch::style::Dimension::Points(50f32), ..Default::default() },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node = stretch
@@ -29,7 +29,7 @@ fn percentage_size_of_flex_basis() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/percentage_width_height.rs
+++ b/tests/generated/percentage_width_height.rs
@@ -11,7 +11,7 @@ fn percentage_width_height() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -24,7 +24,7 @@ fn percentage_width_height() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/percentage_width_height_undefined_parent_size.rs
+++ b/tests/generated/percentage_width_height_undefined_parent_size.rs
@@ -11,13 +11,13 @@ fn percentage_width_height_undefined_parent_size() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
         .new_node(
             stretch::style::Style { flex_direction: stretch::style::FlexDirection::Column, ..Default::default() },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/relative_position_should_not_nudge_siblings.rs
+++ b/tests/generated/relative_position_should_not_nudge_siblings.rs
@@ -14,7 +14,7 @@ fn relative_position_should_not_nudge_siblings() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -30,7 +30,7 @@ fn relative_position_should_not_nudge_siblings() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -44,7 +44,7 @@ fn relative_position_should_not_nudge_siblings() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/rounding_flex_basis_flex_grow_row_prime_number_width.rs
+++ b/tests/generated/rounding_flex_basis_flex_grow_row_prime_number_width.rs
@@ -1,11 +1,11 @@
 #[test]
 fn rounding_flex_basis_flex_grow_row_prime_number_width() {
     let mut stretch = stretch::Stretch::new();
-    let node0 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
-    let node1 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
-    let node2 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
-    let node3 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
-    let node4 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
+    let node0 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node1 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node2 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node3 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node4 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node = stretch
         .new_node(
             stretch::style::Style {
@@ -16,7 +16,7 @@ fn rounding_flex_basis_flex_grow_row_prime_number_width() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2, node3, node4],
+            &[node0, node1, node2, node3, node4],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/rounding_flex_basis_flex_grow_row_width_of_100.rs
+++ b/tests/generated/rounding_flex_basis_flex_grow_row_width_of_100.rs
@@ -1,9 +1,9 @@
 #[test]
 fn rounding_flex_basis_flex_grow_row_width_of_100() {
     let mut stretch = stretch::Stretch::new();
-    let node0 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
-    let node1 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
-    let node2 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, vec![]).unwrap();
+    let node0 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node1 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node2 = stretch.new_node(stretch::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node = stretch
         .new_node(
             stretch::style::Style {
@@ -14,7 +14,7 @@ fn rounding_flex_basis_flex_grow_row_width_of_100() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/rounding_flex_basis_flex_shrink_row.rs
+++ b/tests/generated/rounding_flex_basis_flex_shrink_row.rs
@@ -8,19 +8,19 @@ fn rounding_flex_basis_flex_shrink_row() {
                 flex_basis: stretch::style::Dimension::Points(100f32),
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
         .new_node(
             stretch::style::Style { flex_basis: stretch::style::Dimension::Points(25f32), ..Default::default() },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
         .new_node(
             stretch::style::Style { flex_basis: stretch::style::Dimension::Points(25f32), ..Default::default() },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -33,7 +33,7 @@ fn rounding_flex_basis_flex_shrink_row() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/rounding_flex_basis_overrides_main_size.rs
+++ b/tests/generated/rounding_flex_basis_overrides_main_size.rs
@@ -12,7 +12,7 @@ fn rounding_flex_basis_overrides_main_size() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -25,7 +25,7 @@ fn rounding_flex_basis_overrides_main_size() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -38,7 +38,7 @@ fn rounding_flex_basis_overrides_main_size() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -52,7 +52,7 @@ fn rounding_flex_basis_overrides_main_size() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/rounding_fractial_input_1.rs
+++ b/tests/generated/rounding_fractial_input_1.rs
@@ -12,7 +12,7 @@ fn rounding_fractial_input_1() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -25,7 +25,7 @@ fn rounding_fractial_input_1() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -38,7 +38,7 @@ fn rounding_fractial_input_1() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -52,7 +52,7 @@ fn rounding_fractial_input_1() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/rounding_fractial_input_2.rs
+++ b/tests/generated/rounding_fractial_input_2.rs
@@ -12,7 +12,7 @@ fn rounding_fractial_input_2() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -25,7 +25,7 @@ fn rounding_fractial_input_2() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -38,7 +38,7 @@ fn rounding_fractial_input_2() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -52,7 +52,7 @@ fn rounding_fractial_input_2() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/rounding_fractial_input_3.rs
+++ b/tests/generated/rounding_fractial_input_3.rs
@@ -12,7 +12,7 @@ fn rounding_fractial_input_3() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -25,7 +25,7 @@ fn rounding_fractial_input_3() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -38,7 +38,7 @@ fn rounding_fractial_input_3() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -52,7 +52,7 @@ fn rounding_fractial_input_3() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/rounding_fractial_input_4.rs
+++ b/tests/generated/rounding_fractial_input_4.rs
@@ -12,7 +12,7 @@ fn rounding_fractial_input_4() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -25,7 +25,7 @@ fn rounding_fractial_input_4() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -38,7 +38,7 @@ fn rounding_fractial_input_4() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -52,7 +52,7 @@ fn rounding_fractial_input_4() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/rounding_total_fractial.rs
+++ b/tests/generated/rounding_total_fractial.rs
@@ -12,7 +12,7 @@ fn rounding_total_fractial() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -25,7 +25,7 @@ fn rounding_total_fractial() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -38,7 +38,7 @@ fn rounding_total_fractial() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -52,7 +52,7 @@ fn rounding_total_fractial() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/rounding_total_fractial_nested.rs
+++ b/tests/generated/rounding_total_fractial_nested.rs
@@ -16,7 +16,7 @@ fn rounding_total_fractial_nested() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node01 = stretch
@@ -34,7 +34,7 @@ fn rounding_total_fractial_nested() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -49,7 +49,7 @@ fn rounding_total_fractial_nested() {
                 },
                 ..Default::default()
             },
-            vec![node00, node01],
+            &[node00, node01],
         )
         .unwrap();
     let node1 = stretch
@@ -62,7 +62,7 @@ fn rounding_total_fractial_nested() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -75,7 +75,7 @@ fn rounding_total_fractial_nested() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -89,7 +89,7 @@ fn rounding_total_fractial_nested() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/size_defined_by_child.rs
+++ b/tests/generated/size_defined_by_child.rs
@@ -11,10 +11,10 @@ fn size_defined_by_child() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
-    let node = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node0]).unwrap();
+    let node = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node0]).unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();
     assert_eq!(stretch.layout(node).unwrap().size.width, 100f32);
     assert_eq!(stretch.layout(node).unwrap().size.height, 100f32);

--- a/tests/generated/size_defined_by_child_with_border.rs
+++ b/tests/generated/size_defined_by_child_with_border.rs
@@ -11,7 +11,7 @@ fn size_defined_by_child_with_border() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -26,7 +26,7 @@ fn size_defined_by_child_with_border() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/size_defined_by_child_with_padding.rs
+++ b/tests/generated/size_defined_by_child_with_padding.rs
@@ -11,7 +11,7 @@ fn size_defined_by_child_with_padding() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -26,7 +26,7 @@ fn size_defined_by_child_with_padding() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/size_defined_by_grand_child.rs
+++ b/tests/generated/size_defined_by_grand_child.rs
@@ -11,11 +11,11 @@ fn size_defined_by_grand_child() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
-    let node0 = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node00]).unwrap();
-    let node = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node0]).unwrap();
+    let node0 = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node00]).unwrap();
+    let node = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node0]).unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();
     assert_eq!(stretch.layout(node).unwrap().size.width, 100f32);
     assert_eq!(stretch.layout(node).unwrap().size.height, 100f32);

--- a/tests/generated/width_smaller_then_content_with_flex_grow_large_size.rs
+++ b/tests/generated/width_smaller_then_content_with_flex_grow_large_size.rs
@@ -11,7 +11,7 @@ fn width_smaller_then_content_with_flex_grow_large_size() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -22,7 +22,7 @@ fn width_smaller_then_content_with_flex_grow_large_size() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(0f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node10 = stretch
@@ -35,7 +35,7 @@ fn width_smaller_then_content_with_flex_grow_large_size() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -46,7 +46,7 @@ fn width_smaller_then_content_with_flex_grow_large_size() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(0f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![node10],
+            &[node10],
         )
         .unwrap();
     let node = stretch
@@ -58,7 +58,7 @@ fn width_smaller_then_content_with_flex_grow_large_size() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/width_smaller_then_content_with_flex_grow_small_size.rs
+++ b/tests/generated/width_smaller_then_content_with_flex_grow_small_size.rs
@@ -11,7 +11,7 @@ fn width_smaller_then_content_with_flex_grow_small_size() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -22,7 +22,7 @@ fn width_smaller_then_content_with_flex_grow_small_size() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(0f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node10 = stretch
@@ -35,7 +35,7 @@ fn width_smaller_then_content_with_flex_grow_small_size() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -46,7 +46,7 @@ fn width_smaller_then_content_with_flex_grow_small_size() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(0f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![node10],
+            &[node10],
         )
         .unwrap();
     let node = stretch
@@ -55,7 +55,7 @@ fn width_smaller_then_content_with_flex_grow_small_size() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/width_smaller_then_content_with_flex_grow_unconstraint_size.rs
+++ b/tests/generated/width_smaller_then_content_with_flex_grow_unconstraint_size.rs
@@ -11,7 +11,7 @@ fn width_smaller_then_content_with_flex_grow_unconstraint_size() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -22,7 +22,7 @@ fn width_smaller_then_content_with_flex_grow_unconstraint_size() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(0f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node10 = stretch
@@ -35,7 +35,7 @@ fn width_smaller_then_content_with_flex_grow_unconstraint_size() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -46,10 +46,10 @@ fn width_smaller_then_content_with_flex_grow_unconstraint_size() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(0f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![node10],
+            &[node10],
         )
         .unwrap();
-    let node = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![node0, node1]).unwrap();
+    let node = stretch.new_node(stretch::style::Style { ..Default::default() }, &[node0, node1]).unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();
     assert_eq!(stretch.layout(node).unwrap().size.width, 0f32);
     assert_eq!(stretch.layout(node).unwrap().size.height, 100f32);

--- a/tests/generated/width_smaller_then_content_with_flex_grow_very_large_size.rs
+++ b/tests/generated/width_smaller_then_content_with_flex_grow_very_large_size.rs
@@ -11,7 +11,7 @@ fn width_smaller_then_content_with_flex_grow_very_large_size() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
@@ -22,7 +22,7 @@ fn width_smaller_then_content_with_flex_grow_very_large_size() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(0f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![node00],
+            &[node00],
         )
         .unwrap();
     let node10 = stretch
@@ -35,7 +35,7 @@ fn width_smaller_then_content_with_flex_grow_very_large_size() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -46,7 +46,7 @@ fn width_smaller_then_content_with_flex_grow_very_large_size() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(0f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![node10],
+            &[node10],
         )
         .unwrap();
     let node = stretch
@@ -58,7 +58,7 @@ fn width_smaller_then_content_with_flex_grow_very_large_size() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1],
+            &[node0, node1],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/wrap_column.rs
+++ b/tests/generated/wrap_column.rs
@@ -11,7 +11,7 @@ fn wrap_column() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -24,7 +24,7 @@ fn wrap_column() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -37,7 +37,7 @@ fn wrap_column() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node3 = stretch
@@ -50,7 +50,7 @@ fn wrap_column() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -65,7 +65,7 @@ fn wrap_column() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2, node3],
+            &[node0, node1, node2, node3],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/wrap_nodes_with_content_sizing_margin_cross.rs
+++ b/tests/generated/wrap_nodes_with_content_sizing_margin_cross.rs
@@ -11,13 +11,13 @@ fn wrap_nodes_with_content_sizing_margin_cross() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node00 = stretch
         .new_node(
             stretch::style::Style { flex_direction: stretch::style::FlexDirection::Column, ..Default::default() },
-            vec![node000],
+            &[node000],
         )
         .unwrap();
     let node010 = stretch
@@ -30,7 +30,7 @@ fn wrap_nodes_with_content_sizing_margin_cross() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node01 = stretch
@@ -40,7 +40,7 @@ fn wrap_nodes_with_content_sizing_margin_cross() {
                 margin: stretch::geometry::Rect { top: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![node010],
+            &[node010],
         )
         .unwrap();
     let node0 = stretch
@@ -50,7 +50,7 @@ fn wrap_nodes_with_content_sizing_margin_cross() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(70f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![node00, node01],
+            &[node00, node01],
         )
         .unwrap();
     let node = stretch
@@ -64,7 +64,7 @@ fn wrap_nodes_with_content_sizing_margin_cross() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/wrap_nodes_with_content_sizing_overflowing_margin.rs
+++ b/tests/generated/wrap_nodes_with_content_sizing_overflowing_margin.rs
@@ -11,13 +11,13 @@ fn wrap_nodes_with_content_sizing_overflowing_margin() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node00 = stretch
         .new_node(
             stretch::style::Style { flex_direction: stretch::style::FlexDirection::Column, ..Default::default() },
-            vec![node000],
+            &[node000],
         )
         .unwrap();
     let node010 = stretch
@@ -30,7 +30,7 @@ fn wrap_nodes_with_content_sizing_overflowing_margin() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node01 = stretch
@@ -40,7 +40,7 @@ fn wrap_nodes_with_content_sizing_overflowing_margin() {
                 margin: stretch::geometry::Rect { end: stretch::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![node010],
+            &[node010],
         )
         .unwrap();
     let node0 = stretch
@@ -50,7 +50,7 @@ fn wrap_nodes_with_content_sizing_overflowing_margin() {
                 size: stretch::geometry::Size { width: stretch::style::Dimension::Points(85f32), ..Default::default() },
                 ..Default::default()
             },
-            vec![node00, node01],
+            &[node00, node01],
         )
         .unwrap();
     let node = stretch
@@ -64,7 +64,7 @@ fn wrap_nodes_with_content_sizing_overflowing_margin() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/wrap_reverse_column.rs
+++ b/tests/generated/wrap_reverse_column.rs
@@ -11,7 +11,7 @@ fn wrap_reverse_column() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -24,7 +24,7 @@ fn wrap_reverse_column() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -37,7 +37,7 @@ fn wrap_reverse_column() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node3 = stretch
@@ -50,7 +50,7 @@ fn wrap_reverse_column() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -65,7 +65,7 @@ fn wrap_reverse_column() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2, node3],
+            &[node0, node1, node2, node3],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/wrap_reverse_column_fixed_size.rs
+++ b/tests/generated/wrap_reverse_column_fixed_size.rs
@@ -11,7 +11,7 @@ fn wrap_reverse_column_fixed_size() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -24,7 +24,7 @@ fn wrap_reverse_column_fixed_size() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -37,7 +37,7 @@ fn wrap_reverse_column_fixed_size() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node3 = stretch
@@ -50,7 +50,7 @@ fn wrap_reverse_column_fixed_size() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node4 = stretch
@@ -63,7 +63,7 @@ fn wrap_reverse_column_fixed_size() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -79,7 +79,7 @@ fn wrap_reverse_column_fixed_size() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2, node3, node4],
+            &[node0, node1, node2, node3, node4],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/wrap_reverse_row.rs
+++ b/tests/generated/wrap_reverse_row.rs
@@ -11,7 +11,7 @@ fn wrap_reverse_row() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -24,7 +24,7 @@ fn wrap_reverse_row() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -37,7 +37,7 @@ fn wrap_reverse_row() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node3 = stretch
@@ -50,7 +50,7 @@ fn wrap_reverse_row() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -63,7 +63,7 @@ fn wrap_reverse_row() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2, node3],
+            &[node0, node1, node2, node3],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/wrap_reverse_row_align_content_center.rs
+++ b/tests/generated/wrap_reverse_row_align_content_center.rs
@@ -11,7 +11,7 @@ fn wrap_reverse_row_align_content_center() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -24,7 +24,7 @@ fn wrap_reverse_row_align_content_center() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -37,7 +37,7 @@ fn wrap_reverse_row_align_content_center() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node3 = stretch
@@ -50,7 +50,7 @@ fn wrap_reverse_row_align_content_center() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node4 = stretch
@@ -63,7 +63,7 @@ fn wrap_reverse_row_align_content_center() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -77,7 +77,7 @@ fn wrap_reverse_row_align_content_center() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2, node3, node4],
+            &[node0, node1, node2, node3, node4],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/wrap_reverse_row_align_content_flex_start.rs
+++ b/tests/generated/wrap_reverse_row_align_content_flex_start.rs
@@ -11,7 +11,7 @@ fn wrap_reverse_row_align_content_flex_start() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -24,7 +24,7 @@ fn wrap_reverse_row_align_content_flex_start() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -37,7 +37,7 @@ fn wrap_reverse_row_align_content_flex_start() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node3 = stretch
@@ -50,7 +50,7 @@ fn wrap_reverse_row_align_content_flex_start() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node4 = stretch
@@ -63,7 +63,7 @@ fn wrap_reverse_row_align_content_flex_start() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -77,7 +77,7 @@ fn wrap_reverse_row_align_content_flex_start() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2, node3, node4],
+            &[node0, node1, node2, node3, node4],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/wrap_reverse_row_align_content_space_around.rs
+++ b/tests/generated/wrap_reverse_row_align_content_space_around.rs
@@ -11,7 +11,7 @@ fn wrap_reverse_row_align_content_space_around() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -24,7 +24,7 @@ fn wrap_reverse_row_align_content_space_around() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -37,7 +37,7 @@ fn wrap_reverse_row_align_content_space_around() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node3 = stretch
@@ -50,7 +50,7 @@ fn wrap_reverse_row_align_content_space_around() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node4 = stretch
@@ -63,7 +63,7 @@ fn wrap_reverse_row_align_content_space_around() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -77,7 +77,7 @@ fn wrap_reverse_row_align_content_space_around() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2, node3, node4],
+            &[node0, node1, node2, node3, node4],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/wrap_reverse_row_align_content_stretch.rs
+++ b/tests/generated/wrap_reverse_row_align_content_stretch.rs
@@ -11,7 +11,7 @@ fn wrap_reverse_row_align_content_stretch() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -24,7 +24,7 @@ fn wrap_reverse_row_align_content_stretch() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -37,7 +37,7 @@ fn wrap_reverse_row_align_content_stretch() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node3 = stretch
@@ -50,7 +50,7 @@ fn wrap_reverse_row_align_content_stretch() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node4 = stretch
@@ -63,7 +63,7 @@ fn wrap_reverse_row_align_content_stretch() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -76,7 +76,7 @@ fn wrap_reverse_row_align_content_stretch() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2, node3, node4],
+            &[node0, node1, node2, node3, node4],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/wrap_reverse_row_single_line_different_size.rs
+++ b/tests/generated/wrap_reverse_row_single_line_different_size.rs
@@ -11,7 +11,7 @@ fn wrap_reverse_row_single_line_different_size() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -24,7 +24,7 @@ fn wrap_reverse_row_single_line_different_size() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -37,7 +37,7 @@ fn wrap_reverse_row_single_line_different_size() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node3 = stretch
@@ -50,7 +50,7 @@ fn wrap_reverse_row_single_line_different_size() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node4 = stretch
@@ -63,7 +63,7 @@ fn wrap_reverse_row_single_line_different_size() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -77,7 +77,7 @@ fn wrap_reverse_row_single_line_different_size() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2, node3, node4],
+            &[node0, node1, node2, node3, node4],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/wrap_row.rs
+++ b/tests/generated/wrap_row.rs
@@ -11,7 +11,7 @@ fn wrap_row() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -24,7 +24,7 @@ fn wrap_row() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -37,7 +37,7 @@ fn wrap_row() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node3 = stretch
@@ -50,7 +50,7 @@ fn wrap_row() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -63,7 +63,7 @@ fn wrap_row() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2, node3],
+            &[node0, node1, node2, node3],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/wrap_row_align_items_center.rs
+++ b/tests/generated/wrap_row_align_items_center.rs
@@ -11,7 +11,7 @@ fn wrap_row_align_items_center() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -24,7 +24,7 @@ fn wrap_row_align_items_center() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -37,7 +37,7 @@ fn wrap_row_align_items_center() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node3 = stretch
@@ -50,7 +50,7 @@ fn wrap_row_align_items_center() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -64,7 +64,7 @@ fn wrap_row_align_items_center() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2, node3],
+            &[node0, node1, node2, node3],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/wrap_row_align_items_flex_end.rs
+++ b/tests/generated/wrap_row_align_items_flex_end.rs
@@ -11,7 +11,7 @@ fn wrap_row_align_items_flex_end() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -24,7 +24,7 @@ fn wrap_row_align_items_flex_end() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -37,7 +37,7 @@ fn wrap_row_align_items_flex_end() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node3 = stretch
@@ -50,7 +50,7 @@ fn wrap_row_align_items_flex_end() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -64,7 +64,7 @@ fn wrap_row_align_items_flex_end() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2, node3],
+            &[node0, node1, node2, node3],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/wrapped_column_max_height.rs
+++ b/tests/generated/wrapped_column_max_height.rs
@@ -15,7 +15,7 @@ fn wrapped_column_max_height() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -35,7 +35,7 @@ fn wrapped_column_max_height() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -48,7 +48,7 @@ fn wrapped_column_max_height() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -66,7 +66,7 @@ fn wrapped_column_max_height() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/wrapped_column_max_height_flex.rs
+++ b/tests/generated/wrapped_column_max_height_flex.rs
@@ -18,7 +18,7 @@ fn wrapped_column_max_height_flex() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node1 = stretch
@@ -41,7 +41,7 @@ fn wrapped_column_max_height_flex() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node2 = stretch
@@ -54,7 +54,7 @@ fn wrapped_column_max_height_flex() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node = stretch
@@ -72,7 +72,7 @@ fn wrapped_column_max_height_flex() {
                 },
                 ..Default::default()
             },
-            vec![node0, node1, node2],
+            &[node0, node1, node2],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/wrapped_row_within_align_items_center.rs
+++ b/tests/generated/wrapped_row_within_align_items_center.rs
@@ -11,7 +11,7 @@ fn wrapped_row_within_align_items_center() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node01 = stretch
@@ -24,13 +24,13 @@ fn wrapped_row_within_align_items_center() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
         .new_node(
             stretch::style::Style { flex_wrap: stretch::style::FlexWrap::Wrap, ..Default::default() },
-            vec![node00, node01],
+            &[node00, node01],
         )
         .unwrap();
     let node = stretch
@@ -45,7 +45,7 @@ fn wrapped_row_within_align_items_center() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/wrapped_row_within_align_items_flex_end.rs
+++ b/tests/generated/wrapped_row_within_align_items_flex_end.rs
@@ -11,7 +11,7 @@ fn wrapped_row_within_align_items_flex_end() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node01 = stretch
@@ -24,13 +24,13 @@ fn wrapped_row_within_align_items_flex_end() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
         .new_node(
             stretch::style::Style { flex_wrap: stretch::style::FlexWrap::Wrap, ..Default::default() },
-            vec![node00, node01],
+            &[node00, node01],
         )
         .unwrap();
     let node = stretch
@@ -45,7 +45,7 @@ fn wrapped_row_within_align_items_flex_end() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/generated/wrapped_row_within_align_items_flex_start.rs
+++ b/tests/generated/wrapped_row_within_align_items_flex_start.rs
@@ -11,7 +11,7 @@ fn wrapped_row_within_align_items_flex_start() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node01 = stretch
@@ -24,13 +24,13 @@ fn wrapped_row_within_align_items_flex_start() {
                 },
                 ..Default::default()
             },
-            vec![],
+            &[],
         )
         .unwrap();
     let node0 = stretch
         .new_node(
             stretch::style::Style { flex_wrap: stretch::style::FlexWrap::Wrap, ..Default::default() },
-            vec![node00, node01],
+            &[node00, node01],
         )
         .unwrap();
     let node = stretch
@@ -45,7 +45,7 @@ fn wrapped_row_within_align_items_flex_start() {
                 },
                 ..Default::default()
             },
-            vec![node0],
+            &[node0],
         )
         .unwrap();
     stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();

--- a/tests/measure.rs
+++ b/tests/measure.rs
@@ -1,15 +1,19 @@
 #[cfg(test)]
 mod measure {
+    use stretch::node::MeasureFunc;
     use stretch::number::OrElse;
 
     #[test]
     fn measure_root() {
         let mut stretch = stretch::node::Stretch::new();
         let node = stretch
-            .new_leaf(stretch::style::Style { ..Default::default() }, |constraint| stretch::geometry::Size {
-                width: constraint.width.or_else(100.0),
-                height: constraint.height.or_else(100.0),
-            })
+            .new_leaf(
+                stretch::style::Style { ..Default::default() },
+                MeasureFunc::Raw(|constraint| stretch::geometry::Size {
+                    width: constraint.width.or_else(100.0),
+                    height: constraint.height.or_else(100.0),
+                }),
+            )
             .unwrap();
 
         stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();
@@ -23,10 +27,13 @@ mod measure {
         let mut stretch = stretch::node::Stretch::new();
 
         let child = stretch
-            .new_leaf(stretch::style::Style { ..Default::default() }, |constraint| stretch::geometry::Size {
-                width: constraint.width.or_else(100.0),
-                height: constraint.height.or_else(100.0),
-            })
+            .new_leaf(
+                stretch::style::Style { ..Default::default() },
+                MeasureFunc::Raw(|constraint| stretch::geometry::Size {
+                    width: constraint.width.or_else(100.0),
+                    height: constraint.height.or_else(100.0),
+                }),
+            )
             .unwrap();
 
         let node = stretch.new_node(stretch::style::Style { ..Default::default() }, &[child]).unwrap();
@@ -43,10 +50,13 @@ mod measure {
     fn measure_child_constraint() {
         let mut stretch = stretch::node::Stretch::new();
         let child = stretch
-            .new_leaf(stretch::style::Style { ..Default::default() }, |constraint| stretch::geometry::Size {
-                width: constraint.width.or_else(100.0),
-                height: constraint.height.or_else(100.0),
-            })
+            .new_leaf(
+                stretch::style::Style { ..Default::default() },
+                MeasureFunc::Raw(|constraint| stretch::geometry::Size {
+                    width: constraint.width.or_else(100.0),
+                    height: constraint.height.or_else(100.0),
+                }),
+            )
             .unwrap();
 
         let node = stretch
@@ -75,10 +85,13 @@ mod measure {
     fn measure_child_constraint_padding_parent() {
         let mut stretch = stretch::node::Stretch::new();
         let child = stretch
-            .new_leaf(stretch::style::Style { ..Default::default() }, |constraint| stretch::geometry::Size {
-                width: constraint.width.or_else(100.0),
-                height: constraint.height.or_else(100.0),
-            })
+            .new_leaf(
+                stretch::style::Style { ..Default::default() },
+                MeasureFunc::Raw(|constraint| stretch::geometry::Size {
+                    width: constraint.width.or_else(100.0),
+                    height: constraint.height.or_else(100.0),
+                }),
+            )
             .unwrap();
 
         let node = stretch
@@ -125,12 +138,13 @@ mod measure {
             .unwrap();
 
         let child1 = stretch
-            .new_leaf(stretch::style::Style { flex_grow: 1.0, ..Default::default() }, |constraint| {
-                stretch::geometry::Size {
+            .new_leaf(
+                stretch::style::Style { flex_grow: 1.0, ..Default::default() },
+                MeasureFunc::Raw(|constraint| stretch::geometry::Size {
                     width: constraint.width.or_else(10.0),
                     height: constraint.height.or_else(50.0),
-                }
-            })
+                }),
+            )
             .unwrap();
 
         let node = stretch
@@ -170,10 +184,13 @@ mod measure {
             .unwrap();
 
         let child1 = stretch
-            .new_leaf(stretch::style::Style { ..Default::default() }, |constraint| stretch::geometry::Size {
-                width: constraint.width.or_else(100.0),
-                height: constraint.height.or_else(50.0),
-            })
+            .new_leaf(
+                stretch::style::Style { ..Default::default() },
+                MeasureFunc::Raw(|constraint| stretch::geometry::Size {
+                    width: constraint.width.or_else(100.0),
+                    height: constraint.height.or_else(50.0),
+                }),
+            )
             .unwrap();
 
         let node = stretch
@@ -212,11 +229,14 @@ mod measure {
             .unwrap();
 
         let child1 = stretch
-            .new_leaf(stretch::style::Style { flex_grow: 1.0, ..Default::default() }, |constraint| {
-                let width = constraint.width.or_else(10.0);
-                let height = constraint.height.or_else(width * 2.0);
-                stretch::geometry::Size { width, height }
-            })
+            .new_leaf(
+                stretch::style::Style { flex_grow: 1.0, ..Default::default() },
+                MeasureFunc::Raw(|constraint| {
+                    let width = constraint.width.or_else(10.0);
+                    let height = constraint.height.or_else(width * 2.0);
+                    stretch::geometry::Size { width, height }
+                }),
+            )
             .unwrap();
 
         let node = stretch
@@ -258,11 +278,14 @@ mod measure {
             .unwrap();
 
         let child1 = stretch
-            .new_leaf(stretch::style::Style { ..Default::default() }, |constraint| {
-                let width = constraint.width.or_else(100.0);
-                let height = constraint.height.or_else(width * 2.0);
-                stretch::geometry::Size { width, height }
-            })
+            .new_leaf(
+                stretch::style::Style { ..Default::default() },
+                MeasureFunc::Raw(|constraint| {
+                    let width = constraint.width.or_else(100.0);
+                    let height = constraint.height.or_else(width * 2.0);
+                    stretch::geometry::Size { width, height }
+                }),
+            )
             .unwrap();
 
         let node = stretch
@@ -290,11 +313,14 @@ mod measure {
         let mut stretch = stretch::node::Stretch::new();
 
         let child = stretch
-            .new_leaf(stretch::style::Style { ..Default::default() }, |constraint| {
-                let height = constraint.height.or_else(50.0);
-                let width = constraint.width.or_else(height);
-                stretch::geometry::Size { width, height }
-            })
+            .new_leaf(
+                stretch::style::Style { ..Default::default() },
+                MeasureFunc::Raw(|constraint| {
+                    let height = constraint.height.or_else(50.0);
+                    let width = constraint.width.or_else(height);
+                    stretch::geometry::Size { width, height }
+                }),
+            )
             .unwrap();
 
         let node = stretch
@@ -328,10 +354,10 @@ mod measure {
                     },
                     ..Default::default()
                 },
-                |constraint| stretch::geometry::Size {
+                MeasureFunc::Raw(|constraint| stretch::geometry::Size {
                     width: constraint.width.or_else(100.0),
                     height: constraint.height.or_else(100.0),
-                },
+                }),
             )
             .unwrap();
 
@@ -354,10 +380,10 @@ mod measure {
                     },
                     ..Default::default()
                 },
-                |constraint| stretch::geometry::Size {
+                MeasureFunc::Raw(|constraint| stretch::geometry::Size {
                     width: constraint.width.or_else(100.0),
                     height: constraint.height.or_else(100.0),
-                },
+                }),
             )
             .unwrap();
 
@@ -389,10 +415,10 @@ mod measure {
                     flex_grow: 1.0,
                     ..Default::default()
                 },
-                |constraint| stretch::geometry::Size {
+                MeasureFunc::Raw(|constraint| stretch::geometry::Size {
                     width: constraint.width.or_else(100.0),
                     height: constraint.height.or_else(100.0),
-                },
+                }),
             )
             .unwrap();
 
@@ -421,10 +447,13 @@ mod measure {
     fn stretch_overrides_measure() {
         let mut stretch = stretch::node::Stretch::new();
         let child = stretch
-            .new_leaf(stretch::style::Style { ..Default::default() }, |constraint| stretch::geometry::Size {
-                width: constraint.width.or_else(50.0),
-                height: constraint.height.or_else(50.0),
-            })
+            .new_leaf(
+                stretch::style::Style { ..Default::default() },
+                MeasureFunc::Raw(|constraint| stretch::geometry::Size {
+                    width: constraint.width.or_else(50.0),
+                    height: constraint.height.or_else(50.0),
+                }),
+            )
             .unwrap();
 
         let node = stretch
@@ -452,10 +481,10 @@ mod measure {
         let child = stretch
             .new_leaf(
                 stretch::style::Style { position_type: stretch::style::PositionType::Absolute, ..Default::default() },
-                |constraint| stretch::geometry::Size {
+                MeasureFunc::Raw(|constraint| stretch::geometry::Size {
                     width: constraint.width.or_else(50.0),
                     height: constraint.height.or_else(50.0),
-                },
+                }),
             )
             .unwrap();
 
@@ -482,10 +511,10 @@ mod measure {
     fn ignore_invalid_measure() {
         let mut stretch = stretch::node::Stretch::new();
         let child = stretch
-            .new_leaf(stretch::style::Style { flex_grow: 1.0, ..Default::default() }, |_| stretch::geometry::Size {
-                width: 200.0,
-                height: 200.0,
-            })
+            .new_leaf(
+                stretch::style::Style { flex_grow: 1.0, ..Default::default() },
+                MeasureFunc::Raw(|_| stretch::geometry::Size { width: 200.0, height: 200.0 }),
+            )
             .unwrap();
 
         let node = stretch
@@ -515,13 +544,16 @@ mod measure {
         static NUM_MEASURES: atomic::AtomicU32 = atomic::AtomicU32::new(0);
 
         let grandchild = stretch
-            .new_leaf(stretch::style::Style { ..Default::default() }, |constraint| {
-                NUM_MEASURES.fetch_add(1, atomic::Ordering::Relaxed);
-                stretch::geometry::Size {
-                    width: constraint.width.or_else(50.0),
-                    height: constraint.height.or_else(50.0),
-                }
-            })
+            .new_leaf(
+                stretch::style::Style { ..Default::default() },
+                MeasureFunc::Raw(|constraint| {
+                    NUM_MEASURES.fetch_add(1, atomic::Ordering::Relaxed);
+                    stretch::geometry::Size {
+                        width: constraint.width.or_else(50.0),
+                        height: constraint.height.or_else(50.0),
+                    }
+                }),
+            )
             .unwrap();
 
         let child = stretch.new_node(stretch::style::Style { ..Default::default() }, &[grandchild]).unwrap();

--- a/tests/measure.rs
+++ b/tests/measure.rs
@@ -6,15 +6,10 @@ mod measure {
     fn measure_root() {
         let mut stretch = stretch::node::Stretch::new();
         let node = stretch
-            .new_leaf(
-                stretch::style::Style { ..Default::default() },
-                Box::new(|constraint| {
-                    Ok(stretch::geometry::Size {
-                        width: constraint.width.or_else(100.0),
-                        height: constraint.height.or_else(100.0),
-                    })
-                }),
-            )
+            .new_leaf(stretch::style::Style { ..Default::default() }, |constraint| stretch::geometry::Size {
+                width: constraint.width.or_else(100.0),
+                height: constraint.height.or_else(100.0),
+            })
             .unwrap();
 
         stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();
@@ -28,18 +23,13 @@ mod measure {
         let mut stretch = stretch::node::Stretch::new();
 
         let child = stretch
-            .new_leaf(
-                stretch::style::Style { ..Default::default() },
-                Box::new(|constraint| {
-                    Ok(stretch::geometry::Size {
-                        width: constraint.width.or_else(100.0),
-                        height: constraint.height.or_else(100.0),
-                    })
-                }),
-            )
+            .new_leaf(stretch::style::Style { ..Default::default() }, |constraint| stretch::geometry::Size {
+                width: constraint.width.or_else(100.0),
+                height: constraint.height.or_else(100.0),
+            })
             .unwrap();
 
-        let node = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![child]).unwrap();
+        let node = stretch.new_node(stretch::style::Style { ..Default::default() }, &[child]).unwrap();
         stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();
 
         assert_eq!(stretch.layout(node).unwrap().size.width, 100.0);
@@ -53,15 +43,10 @@ mod measure {
     fn measure_child_constraint() {
         let mut stretch = stretch::node::Stretch::new();
         let child = stretch
-            .new_leaf(
-                stretch::style::Style { ..Default::default() },
-                Box::new(|constraint| {
-                    Ok(stretch::geometry::Size {
-                        width: constraint.width.or_else(100.0),
-                        height: constraint.height.or_else(100.0),
-                    })
-                }),
-            )
+            .new_leaf(stretch::style::Style { ..Default::default() }, |constraint| stretch::geometry::Size {
+                width: constraint.width.or_else(100.0),
+                height: constraint.height.or_else(100.0),
+            })
             .unwrap();
 
         let node = stretch
@@ -73,7 +58,7 @@ mod measure {
                     },
                     ..Default::default()
                 },
-                vec![child],
+                &[child],
             )
             .unwrap();
 
@@ -90,15 +75,10 @@ mod measure {
     fn measure_child_constraint_padding_parent() {
         let mut stretch = stretch::node::Stretch::new();
         let child = stretch
-            .new_leaf(
-                stretch::style::Style { ..Default::default() },
-                Box::new(|constraint| {
-                    Ok(stretch::geometry::Size {
-                        width: constraint.width.or_else(100.0),
-                        height: constraint.height.or_else(100.0),
-                    })
-                }),
-            )
+            .new_leaf(stretch::style::Style { ..Default::default() }, |constraint| stretch::geometry::Size {
+                width: constraint.width.or_else(100.0),
+                height: constraint.height.or_else(100.0),
+            })
             .unwrap();
 
         let node = stretch
@@ -116,7 +96,7 @@ mod measure {
                     },
                     ..Default::default()
                 },
-                vec![child],
+                &[child],
             )
             .unwrap();
         stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();
@@ -140,20 +120,17 @@ mod measure {
                     },
                     ..Default::default()
                 },
-                vec![],
+                &[],
             )
             .unwrap();
 
         let child1 = stretch
-            .new_leaf(
-                stretch::style::Style { flex_grow: 1.0, ..Default::default() },
-                Box::new(|constraint| {
-                    Ok(stretch::geometry::Size {
-                        width: constraint.width.or_else(10.0),
-                        height: constraint.height.or_else(50.0),
-                    })
-                }),
-            )
+            .new_leaf(stretch::style::Style { flex_grow: 1.0, ..Default::default() }, |constraint| {
+                stretch::geometry::Size {
+                    width: constraint.width.or_else(10.0),
+                    height: constraint.height.or_else(50.0),
+                }
+            })
             .unwrap();
 
         let node = stretch
@@ -165,7 +142,7 @@ mod measure {
                     },
                     ..Default::default()
                 },
-                vec![child0, child1],
+                &[child0, child1],
             )
             .unwrap();
 
@@ -188,20 +165,15 @@ mod measure {
                     flex_shrink: 0.0,
                     ..Default::default()
                 },
-                vec![],
+                &[],
             )
             .unwrap();
 
         let child1 = stretch
-            .new_leaf(
-                stretch::style::Style { ..Default::default() },
-                Box::new(|constraint| {
-                    Ok(stretch::geometry::Size {
-                        width: constraint.width.or_else(100.0),
-                        height: constraint.height.or_else(50.0),
-                    })
-                }),
-            )
+            .new_leaf(stretch::style::Style { ..Default::default() }, |constraint| stretch::geometry::Size {
+                width: constraint.width.or_else(100.0),
+                height: constraint.height.or_else(50.0),
+            })
             .unwrap();
 
         let node = stretch
@@ -213,7 +185,7 @@ mod measure {
                     },
                     ..Default::default()
                 },
-                vec![child0, child1],
+                &[child0, child1],
             )
             .unwrap();
 
@@ -235,19 +207,16 @@ mod measure {
                     },
                     ..Default::default()
                 },
-                vec![],
+                &[],
             )
             .unwrap();
 
         let child1 = stretch
-            .new_leaf(
-                stretch::style::Style { flex_grow: 1.0, ..Default::default() },
-                Box::new(|constraint| {
-                    let width = constraint.width.or_else(10.0);
-                    let height = constraint.height.or_else(width * 2.0);
-                    Ok(stretch::geometry::Size { width, height })
-                }),
-            )
+            .new_leaf(stretch::style::Style { flex_grow: 1.0, ..Default::default() }, |constraint| {
+                let width = constraint.width.or_else(10.0);
+                let height = constraint.height.or_else(width * 2.0);
+                stretch::geometry::Size { width, height }
+            })
             .unwrap();
 
         let node = stretch
@@ -260,7 +229,7 @@ mod measure {
                     align_items: stretch::style::AlignItems::FlexStart,
                     ..Default::default()
                 },
-                vec![child0, child1],
+                &[child0, child1],
             )
             .unwrap();
 
@@ -284,19 +253,16 @@ mod measure {
                     flex_shrink: 0.0,
                     ..Default::default()
                 },
-                vec![],
+                &[],
             )
             .unwrap();
 
         let child1 = stretch
-            .new_leaf(
-                stretch::style::Style { ..Default::default() },
-                Box::new(|constraint| {
-                    let width = constraint.width.or_else(100.0);
-                    let height = constraint.height.or_else(width * 2.0);
-                    Ok(stretch::geometry::Size { width, height })
-                }),
-            )
+            .new_leaf(stretch::style::Style { ..Default::default() }, |constraint| {
+                let width = constraint.width.or_else(100.0);
+                let height = constraint.height.or_else(width * 2.0);
+                stretch::geometry::Size { width, height }
+            })
             .unwrap();
 
         let node = stretch
@@ -309,7 +275,7 @@ mod measure {
                     align_items: stretch::style::AlignItems::FlexStart,
                     ..Default::default()
                 },
-                vec![child0, child1],
+                &[child0, child1],
             )
             .unwrap();
 
@@ -324,14 +290,11 @@ mod measure {
         let mut stretch = stretch::node::Stretch::new();
 
         let child = stretch
-            .new_leaf(
-                stretch::style::Style { ..Default::default() },
-                Box::new(|constraint| {
-                    let height = constraint.height.or_else(50.0);
-                    let width = constraint.width.or_else(height);
-                    Ok(stretch::geometry::Size { width, height })
-                }),
-            )
+            .new_leaf(stretch::style::Style { ..Default::default() }, |constraint| {
+                let height = constraint.height.or_else(50.0);
+                let width = constraint.width.or_else(height);
+                stretch::geometry::Size { width, height }
+            })
             .unwrap();
 
         let node = stretch
@@ -343,7 +306,7 @@ mod measure {
                     },
                     ..Default::default()
                 },
-                vec![child],
+                &[child],
             )
             .unwrap();
 
@@ -365,16 +328,14 @@ mod measure {
                     },
                     ..Default::default()
                 },
-                Box::new(|constraint| {
-                    Ok(stretch::geometry::Size {
-                        width: constraint.width.or_else(100.0),
-                        height: constraint.height.or_else(100.0),
-                    })
-                }),
+                |constraint| stretch::geometry::Size {
+                    width: constraint.width.or_else(100.0),
+                    height: constraint.height.or_else(100.0),
+                },
             )
             .unwrap();
 
-        let node = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![child]).unwrap();
+        let node = stretch.new_node(stretch::style::Style { ..Default::default() }, &[child]).unwrap();
         stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();
 
         assert_eq!(stretch.layout(child).unwrap().size.width, 50.0);
@@ -393,16 +354,14 @@ mod measure {
                     },
                     ..Default::default()
                 },
-                Box::new(|constraint| {
-                    Ok(stretch::geometry::Size {
-                        width: constraint.width.or_else(100.0),
-                        height: constraint.height.or_else(100.0),
-                    })
-                }),
+                |constraint| stretch::geometry::Size {
+                    width: constraint.width.or_else(100.0),
+                    height: constraint.height.or_else(100.0),
+                },
             )
             .unwrap();
 
-        let node = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![child]).unwrap();
+        let node = stretch.new_node(stretch::style::Style { ..Default::default() }, &[child]).unwrap();
         stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();
 
         assert_eq!(stretch.layout(child).unwrap().size.width, 100.0);
@@ -419,7 +378,7 @@ mod measure {
                     flex_grow: 1.0,
                     ..Default::default()
                 },
-                vec![],
+                &[],
             )
             .unwrap();
 
@@ -430,12 +389,10 @@ mod measure {
                     flex_grow: 1.0,
                     ..Default::default()
                 },
-                Box::new(|constraint| {
-                    Ok(stretch::geometry::Size {
-                        width: constraint.width.or_else(100.0),
-                        height: constraint.height.or_else(100.0),
-                    })
-                }),
+                |constraint| stretch::geometry::Size {
+                    width: constraint.width.or_else(100.0),
+                    height: constraint.height.or_else(100.0),
+                },
             )
             .unwrap();
 
@@ -448,7 +405,7 @@ mod measure {
                     },
                     ..Default::default()
                 },
-                vec![child0, child1],
+                &[child0, child1],
             )
             .unwrap();
 
@@ -464,15 +421,10 @@ mod measure {
     fn stretch_overrides_measure() {
         let mut stretch = stretch::node::Stretch::new();
         let child = stretch
-            .new_leaf(
-                stretch::style::Style { ..Default::default() },
-                Box::new(|constraint| {
-                    Ok(stretch::geometry::Size {
-                        width: constraint.width.or_else(50.0),
-                        height: constraint.height.or_else(50.0),
-                    })
-                }),
-            )
+            .new_leaf(stretch::style::Style { ..Default::default() }, |constraint| stretch::geometry::Size {
+                width: constraint.width.or_else(50.0),
+                height: constraint.height.or_else(50.0),
+            })
             .unwrap();
 
         let node = stretch
@@ -484,7 +436,7 @@ mod measure {
                     },
                     ..Default::default()
                 },
-                vec![child],
+                &[child],
             )
             .unwrap();
 
@@ -500,12 +452,10 @@ mod measure {
         let child = stretch
             .new_leaf(
                 stretch::style::Style { position_type: stretch::style::PositionType::Absolute, ..Default::default() },
-                Box::new(|constraint| {
-                    Ok(stretch::geometry::Size {
-                        width: constraint.width.or_else(50.0),
-                        height: constraint.height.or_else(50.0),
-                    })
-                }),
+                |constraint| stretch::geometry::Size {
+                    width: constraint.width.or_else(50.0),
+                    height: constraint.height.or_else(50.0),
+                },
             )
             .unwrap();
 
@@ -518,7 +468,7 @@ mod measure {
                     },
                     ..Default::default()
                 },
-                vec![child],
+                &[child],
             )
             .unwrap();
 
@@ -532,10 +482,10 @@ mod measure {
     fn ignore_invalid_measure() {
         let mut stretch = stretch::node::Stretch::new();
         let child = stretch
-            .new_leaf(
-                stretch::style::Style { flex_grow: 1.0, ..Default::default() },
-                Box::new(|_| Ok(stretch::geometry::Size { width: 200.0, height: 200.0 })),
-            )
+            .new_leaf(stretch::style::Style { flex_grow: 1.0, ..Default::default() }, |_| stretch::geometry::Size {
+                width: 200.0,
+                height: 200.0,
+            })
             .unwrap();
 
         let node = stretch
@@ -547,7 +497,7 @@ mod measure {
                     },
                     ..Default::default()
                 },
-                vec![child],
+                &[child],
             )
             .unwrap();
 
@@ -559,51 +509,26 @@ mod measure {
 
     #[test]
     fn only_measure_once() {
+        use std::sync::atomic;
+
         let mut stretch = stretch::node::Stretch::new();
-        let mut num_measure = 0;
-        let num_measure_ptr = &mut num_measure as *mut i32;
+        static NUM_MEASURES: atomic::AtomicU32 = atomic::AtomicU32::new(0);
 
         let grandchild = stretch
-            .new_leaf(
-                stretch::style::Style { ..Default::default() },
-                Box::new(move |constraint| {
-                    unsafe { (*num_measure_ptr) += 1 };
-                    Ok(stretch::geometry::Size {
-                        width: constraint.width.or_else(50.0),
-                        height: constraint.height.or_else(50.0),
-                    })
-                }),
-            )
+            .new_leaf(stretch::style::Style { ..Default::default() }, |constraint| {
+                NUM_MEASURES.fetch_add(1, atomic::Ordering::Relaxed);
+                stretch::geometry::Size {
+                    width: constraint.width.or_else(50.0),
+                    height: constraint.height.or_else(50.0),
+                }
+            })
             .unwrap();
 
-        let child = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![grandchild]).unwrap();
+        let child = stretch.new_node(stretch::style::Style { ..Default::default() }, &[grandchild]).unwrap();
 
-        let node = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![child]).unwrap();
+        let node = stretch.new_node(stretch::style::Style { ..Default::default() }, &[child]).unwrap();
         stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();
 
-        assert_eq!(num_measure, 1);
-    }
-
-    #[test]
-    fn propagate_measure_error() {
-        let mut stretch = stretch::node::Stretch::new();
-        let child = stretch
-            .new_leaf(stretch::style::Style { flex_grow: 1.0, ..Default::default() }, Box::new(|_| Err(Box::new(""))))
-            .unwrap();
-
-        let node = stretch
-            .new_node(
-                stretch::style::Style {
-                    size: stretch::geometry::Size {
-                        width: stretch::style::Dimension::Points(100.0),
-                        height: stretch::style::Dimension::Points(100.0),
-                    },
-                    ..Default::default()
-                },
-                vec![child],
-            )
-            .unwrap();
-
-        assert_eq!(stretch.compute_layout(node, stretch::geometry::Size::undefined()).is_err(), true);
+        assert_eq!(NUM_MEASURES.load(atomic::Ordering::Relaxed), 1);
     }
 }

--- a/tests/node.rs
+++ b/tests/node.rs
@@ -7,9 +7,9 @@ mod node {
     #[test]
     fn children() {
         let mut stretch = Stretch::new();
-        let child1 = stretch.new_node(Style::default(), vec![]).unwrap();
-        let child2 = stretch.new_node(Style::default(), vec![]).unwrap();
-        let node = stretch.new_node(Style::default(), vec![child1, child2]).unwrap();
+        let child1 = stretch.new_node(Style::default(), &[]).unwrap();
+        let child2 = stretch.new_node(Style::default(), &[]).unwrap();
+        let node = stretch.new_node(Style::default(), &[child1, child2]).unwrap();
 
         assert_eq!(stretch.child_count(node).unwrap(), 2);
         assert_eq!(stretch.children(node).unwrap()[0], child1);
@@ -19,11 +19,11 @@ mod node {
     #[test]
     fn set_measure() {
         let mut stretch = Stretch::new();
-        let node = stretch.new_leaf(Style::default(), Box::new(|_| Ok(Size { width: 200.0, height: 200.0 }))).unwrap();
+        let node = stretch.new_leaf(Style::default(), |_| Size { width: 200.0, height: 200.0 }).unwrap();
         stretch.compute_layout(node, Size::undefined()).unwrap();
         assert_eq!(stretch.layout(node).unwrap().size.width, 200.0);
 
-        stretch.set_measure(node, Some(Box::new(|_| Ok(Size { width: 100.0, height: 100.0 })))).unwrap();
+        stretch.set_measure(node, Some(|_| Size { width: 100.0, height: 100.0 })).unwrap();
         stretch.compute_layout(node, Size::undefined()).unwrap();
         assert_eq!(stretch.layout(node).unwrap().size.width, 100.0);
     }
@@ -31,14 +31,14 @@ mod node {
     #[test]
     fn add_child() {
         let mut stretch = Stretch::new();
-        let node = stretch.new_node(Style::default(), vec![]).unwrap();
+        let node = stretch.new_node(Style::default(), &[]).unwrap();
         assert_eq!(stretch.child_count(node).unwrap(), 0);
 
-        let child1 = stretch.new_node(Style::default(), vec![]).unwrap();
+        let child1 = stretch.new_node(Style::default(), &[]).unwrap();
         stretch.add_child(node, child1).unwrap();
         assert_eq!(stretch.child_count(node).unwrap(), 1);
 
-        let child2 = stretch.new_node(Style::default(), vec![]).unwrap();
+        let child2 = stretch.new_node(Style::default(), &[]).unwrap();
         stretch.add_child(node, child2).unwrap();
         assert_eq!(stretch.child_count(node).unwrap(), 2);
     }
@@ -47,10 +47,10 @@ mod node {
     fn remove_child() {
         let mut stretch = Stretch::new();
 
-        let child1 = stretch.new_node(Style::default(), vec![]).unwrap();
-        let child2 = stretch.new_node(Style::default(), vec![]).unwrap();
+        let child1 = stretch.new_node(Style::default(), &[]).unwrap();
+        let child2 = stretch.new_node(Style::default(), &[]).unwrap();
 
-        let node = stretch.new_node(Style::default(), vec![child1, child2]).unwrap();
+        let node = stretch.new_node(Style::default(), &[child1, child2]).unwrap();
         assert_eq!(stretch.child_count(node).unwrap(), 2);
 
         stretch.remove_child(node, child1).unwrap();
@@ -65,10 +65,10 @@ mod node {
     fn remove_child_at_index() {
         let mut stretch = Stretch::new();
 
-        let child1 = stretch.new_node(Style::default(), vec![]).unwrap();
-        let child2 = stretch.new_node(Style::default(), vec![]).unwrap();
+        let child1 = stretch.new_node(Style::default(), &[]).unwrap();
+        let child2 = stretch.new_node(Style::default(), &[]).unwrap();
 
-        let node = stretch.new_node(Style::default(), vec![child1, child2]).unwrap();
+        let node = stretch.new_node(Style::default(), &[child1, child2]).unwrap();
         assert_eq!(stretch.child_count(node).unwrap(), 2);
 
         stretch.remove_child_at_index(node, 0).unwrap();
@@ -83,10 +83,10 @@ mod node {
     fn replace_child_at_index() {
         let mut stretch = Stretch::new();
 
-        let child1 = stretch.new_node(Style::default(), vec![]).unwrap();
-        let child2 = stretch.new_node(Style::default(), vec![]).unwrap();
+        let child1 = stretch.new_node(Style::default(), &[]).unwrap();
+        let child2 = stretch.new_node(Style::default(), &[]).unwrap();
 
-        let node = stretch.new_node(Style::default(), vec![child1]).unwrap();
+        let node = stretch.new_node(Style::default(), &[child1]).unwrap();
         assert_eq!(stretch.child_count(node).unwrap(), 1);
         assert_eq!(stretch.children(node).unwrap()[0], child1);
 
@@ -102,11 +102,11 @@ mod node {
         let style2 = Style { flex_direction: FlexDirection::Column, ..Style::default() };
 
         // Build a linear tree layout: <0> <- <1> <- <2>
-        let node2 = stretch.new_node(style2, vec![]).unwrap();
-        let node1 = stretch.new_node(Style::default(), vec![node2]).unwrap();
-        let node0 = stretch.new_node(Style::default(), vec![node1]).unwrap();
+        let node2 = stretch.new_node(style2, &[]).unwrap();
+        let node1 = stretch.new_node(Style::default(), &[node2]).unwrap();
+        let node0 = stretch.new_node(Style::default(), &[node1]).unwrap();
 
-        assert_eq!(stretch.children(node0).unwrap(), vec![node1]);
+        assert_eq!(stretch.children(node0).unwrap().as_slice(), &[node1]);
 
         // Disconnect the tree: <0> <2>
         stretch.remove(node1);
@@ -122,17 +122,17 @@ mod node {
     fn set_children() {
         let mut stretch = Stretch::new();
 
-        let child1 = stretch.new_node(Style::default(), vec![]).unwrap();
-        let child2 = stretch.new_node(Style::default(), vec![]).unwrap();
-        let node = stretch.new_node(Style::default(), vec![child1, child2]).unwrap();
+        let child1 = stretch.new_node(Style::default(), &[]).unwrap();
+        let child2 = stretch.new_node(Style::default(), &[]).unwrap();
+        let node = stretch.new_node(Style::default(), &[child1, child2]).unwrap();
 
         assert_eq!(stretch.child_count(node).unwrap(), 2);
         assert_eq!(stretch.children(node).unwrap()[0], child1);
         assert_eq!(stretch.children(node).unwrap()[1], child2);
 
-        let child3 = stretch.new_node(Style::default(), vec![]).unwrap();
-        let child4 = stretch.new_node(Style::default(), vec![]).unwrap();
-        stretch.set_children(node, vec![child3, child4]).unwrap();
+        let child3 = stretch.new_node(Style::default(), &[]).unwrap();
+        let child4 = stretch.new_node(Style::default(), &[]).unwrap();
+        stretch.set_children(node, &[child3, child4]).unwrap();
 
         assert_eq!(stretch.child_count(node).unwrap(), 2);
         assert_eq!(stretch.children(node).unwrap()[0], child3);
@@ -143,7 +143,7 @@ mod node {
     fn set_style() {
         let mut stretch = Stretch::new();
 
-        let node = stretch.new_node(Style::default(), vec![]).unwrap();
+        let node = stretch.new_node(Style::default(), &[]).unwrap();
         assert_eq!(stretch.style(node).unwrap().display, Display::Flex);
 
         stretch.set_style(node, Style { display: Display::None, ..Style::default() }).unwrap();
@@ -154,9 +154,9 @@ mod node {
     fn mark_dirty() {
         let mut stretch = Stretch::new();
 
-        let child1 = stretch.new_node(Style::default(), vec![]).unwrap();
-        let child2 = stretch.new_node(Style::default(), vec![]).unwrap();
-        let node = stretch.new_node(Style::default(), vec![child1, child2]).unwrap();
+        let child1 = stretch.new_node(Style::default(), &[]).unwrap();
+        let child2 = stretch.new_node(Style::default(), &[]).unwrap();
+        let node = stretch.new_node(Style::default(), &[child1, child2]).unwrap();
 
         stretch.compute_layout(node, stretch::geometry::Size::undefined()).unwrap();
 
@@ -180,8 +180,8 @@ mod node {
     fn remove_last_node() {
         let mut stretch = Stretch::new();
 
-        let parent = stretch.new_node(Style::default(), vec![]).unwrap();
-        let child = stretch.new_node(Style::default(), vec![]).unwrap();
+        let parent = stretch.new_node(Style::default(), &[]).unwrap();
+        let child = stretch.new_node(Style::default(), &[]).unwrap();
         stretch.add_child(parent, child).unwrap();
 
         stretch.remove(child);

--- a/tests/node.rs
+++ b/tests/node.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod node {
     use stretch::geometry::*;
-    use stretch::node::Stretch;
+    use stretch::node::{MeasureFunc, Stretch};
     use stretch::style::*;
 
     #[test]
@@ -19,11 +19,12 @@ mod node {
     #[test]
     fn set_measure() {
         let mut stretch = Stretch::new();
-        let node = stretch.new_leaf(Style::default(), |_| Size { width: 200.0, height: 200.0 }).unwrap();
+        let node =
+            stretch.new_leaf(Style::default(), MeasureFunc::Raw(|_| Size { width: 200.0, height: 200.0 })).unwrap();
         stretch.compute_layout(node, Size::undefined()).unwrap();
         assert_eq!(stretch.layout(node).unwrap().size.width, 200.0);
 
-        stretch.set_measure(node, Some(|_| Size { width: 100.0, height: 100.0 })).unwrap();
+        stretch.set_measure(node, Some(MeasureFunc::Raw(|_| Size { width: 100.0, height: 100.0 }))).unwrap();
         stretch.compute_layout(node, Size::undefined()).unwrap();
         assert_eq!(stretch.layout(node).unwrap().size.width, 100.0);
     }

--- a/tests/root_constraints.rs
+++ b/tests/root_constraints.rs
@@ -14,7 +14,7 @@ mod root_constraints {
                     },
                     ..Default::default()
                 },
-                vec![],
+                &[],
             )
             .unwrap();
 
@@ -33,7 +33,7 @@ mod root_constraints {
     #[test]
     fn root_with_no_size() {
         let mut stretch = stretch::node::Stretch::new();
-        let node = stretch.new_node(stretch::style::Style { ..Default::default() }, vec![]).unwrap();
+        let node = stretch.new_node(stretch::style::Style { ..Default::default() }, &[]).unwrap();
 
         stretch
             .compute_layout(
@@ -59,7 +59,7 @@ mod root_constraints {
                     },
                     ..Default::default()
                 },
-                vec![],
+                &[],
             )
             .unwrap();
 


### PR DESCRIPTION
This is a big change that allows us to run the library without a heap (of course feature gated).

Some trade-offs that have been made:

  - I changed `Id` from using a pair of `u32` to using a single `u64`.  This removes the need to re-use IDs.  Conceivably we could overflow `u64` but this shouldn't happen until the death of the universe.
  - To get the current crate `no_std` + `alloc` behavior, you need to activate the `alloc` feature. I guess this is a breaking change if someone was relying on `default-features = false` in their `Cargo.toml`...
  - The public API no longer contains any allocations like `Vec` or `Box`, as a result measure functions can no longer return errors, and you need to use unboxed closures.  If there is a need it should be easy to add back boxed closures.
  - For the heapless mode, a cap had to be put on the number of elements supported.  The max number of nodes is 256 and only vecs up to size 8 are supported.  This can easily be controlled through the `sys` module.  One big limiting factor is that some algorithms use `Vec<Vec<...>>` which for heapless mode allocates 8*8=64 memory cells.  For non-heapless mode, we still support an indefinite number of nodes/elements.