### PR TITLE
add bench for depth performances

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,5 +55,9 @@ harness = false
 name = "complex"
 harness = false
 
+[[bench]]
+name = "simple_deep"
+harness = false
+
 [workspace]
 members = [ "scripts/gentest" ]

--- a/benches/simple_deep.rs
+++ b/benches/simple_deep.rs
@@ -1,0 +1,55 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn build_deep_hierarchy(stretch: &mut stretch::node::Stretch) -> stretch::node::Node {
+    let parent_node = stretch
+        .new_node(
+            stretch::style::Style {
+                size: stretch::geometry::Size {
+                    width: stretch::style::Dimension::Points(50.),
+                    height: stretch::style::Dimension::Points(50.),
+                },
+                ..Default::default()
+            },
+            &[],
+        )
+        .unwrap();
+    let mut child = stretch.new_node(stretch::style::Style::default(), &[]).unwrap();
+    stretch.set_children(parent_node, &[child]).unwrap();
+
+    for _i in 0..14 {
+        let new_child = stretch.new_node(stretch::style::Style::default(), &[]).unwrap();
+        stretch.set_children(child, &[new_child]).unwrap();
+        child = new_child;
+    }
+    parent_node
+}
+
+fn stretch_benchmarks(c: &mut Criterion) {
+    c.bench_function("simple deep hierarchy - build", |b| {
+        b.iter(|| {
+            let mut stretch = stretch::node::Stretch::new();
+            build_deep_hierarchy(&mut stretch);
+        })
+    });
+
+    c.bench_function("simple deep hierarchy - single", |b| {
+        b.iter(|| {
+            let mut stretch = stretch::node::Stretch::new();
+            let root = build_deep_hierarchy(&mut stretch);
+            stretch.compute_layout(root, stretch::geometry::Size::undefined()).unwrap()
+        })
+    });
+
+    c.bench_function("simple deep hierarchy - relayout", |b| {
+        let mut stretch = stretch::node::Stretch::new();
+        let root = build_deep_hierarchy(&mut stretch);
+
+        b.iter(|| {
+            stretch.mark_dirty(root);
+            stretch.compute_layout(root, stretch::geometry::Size::undefined()).unwrap()
+        })
+    });
+}
+
+criterion_group!(benches, stretch_benchmarks);
+criterion_main!(benches);


### PR DESCRIPTION
related to #71 

on my local machine, took 7m24s:
```
cargo bench --bench simple_deep
   Compiling stretch v0.3.2 (/Users/francois/Dev/spaceward-ho/stretch)
warning: unused `std::result::Result` that must be used
  --> benches/simple_deep.rs:48:13
   |
48 |             stretch.mark_dirty(root);
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_must_use)]` on by default
   = note: this `Result` may be an `Err` variant, which should be handled

warning: 1 warning emitted

    Finished bench [optimized] target(s) in 2.53s
     Running target/release/deps/simple_deep-c97ff526f7fd7766
simple deep hierarchy - build
                        time:   [9.3641 us 9.4032 us 9.4477 us]
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe

Benchmarking simple deep hierarchy - single: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 210.9s, or reduce sample count to 10.
simple deep hierarchy - single
                        time:   [2.0722 s 2.0818 s 2.0922 s]
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe

Benchmarking simple deep hierarchy - relayout: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 208.3s, or reduce sample count to 10.
simple deep hierarchy - relayout
                        time:   [2.0639 s 2.0697 s 2.0756 s]
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
```