### PR TITLE
fix child vector generation for test fixtures and re-generate test fixtures

### DIFF
--- a/scripts/gentest/src/main.rs
+++ b/scripts/gentest/src/main.rs
@@ -425,9 +425,9 @@ fn generate_node(ident: &str, node: &json::JsonValue) -> TokenStream {
                     .enumerate()
                     .map(|(i, _)| Ident::new(&format!("{}{}", ident, i), Span::call_site()))
                     .collect::<Vec<_>>();
-                (body, quote!(vec![#(#idents),*]))
+                (body, quote!(&[#(#idents),*]))
             } else {
-                (quote!(), quote!(vec![]))
+                (quote!(), quote!(&[]))
             }
         }
         _ => (quote!(), quote!()),

--- a/tests/generated/min_height.rs
+++ b/tests/generated/min_height.rs
@@ -35,11 +35,11 @@ fn min_height() {
     assert_eq!(stretch.layout(node).unwrap().location.x, 0f32);
     assert_eq!(stretch.layout(node).unwrap().location.y, 0f32);
     assert_eq!(stretch.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(stretch.layout(node0).unwrap().size.height, 80f32);
+    assert_eq!(stretch.layout(node0).unwrap().size.height, 60f32);
     assert_eq!(stretch.layout(node0).unwrap().location.x, 0f32);
     assert_eq!(stretch.layout(node0).unwrap().location.y, 0f32);
     assert_eq!(stretch.layout(node1).unwrap().size.width, 100f32);
-    assert_eq!(stretch.layout(node1).unwrap().size.height, 20f32);
+    assert_eq!(stretch.layout(node1).unwrap().size.height, 40f32);
     assert_eq!(stretch.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(stretch.layout(node1).unwrap().location.y, 80f32);
+    assert_eq!(stretch.layout(node1).unwrap().location.y, 60f32);
 }

--- a/tests/generated/min_width.rs
+++ b/tests/generated/min_width.rs
@@ -33,12 +33,12 @@ fn min_width() {
     assert_eq!(stretch.layout(node).unwrap().size.height, 100f32);
     assert_eq!(stretch.layout(node).unwrap().location.x, 0f32);
     assert_eq!(stretch.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(stretch.layout(node0).unwrap().size.width, 80f32);
+    assert_eq!(stretch.layout(node0).unwrap().size.width, 60f32);
     assert_eq!(stretch.layout(node0).unwrap().size.height, 100f32);
     assert_eq!(stretch.layout(node0).unwrap().location.x, 0f32);
     assert_eq!(stretch.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(stretch.layout(node1).unwrap().size.width, 20f32);
+    assert_eq!(stretch.layout(node1).unwrap().size.width, 40f32);
     assert_eq!(stretch.layout(node1).unwrap().size.height, 100f32);
-    assert_eq!(stretch.layout(node1).unwrap().location.x, 80f32);
+    assert_eq!(stretch.layout(node1).unwrap().location.x, 60f32);
     assert_eq!(stretch.layout(node1).unwrap().location.y, 0f32);
 }

--- a/tests/generated/percentage_flex_basis_cross_min_height.rs
+++ b/tests/generated/percentage_flex_basis_cross_min_height.rs
@@ -47,11 +47,11 @@ fn percentage_flex_basis_cross_min_height() {
     assert_eq!(stretch.layout(node).unwrap().location.x, 0f32);
     assert_eq!(stretch.layout(node).unwrap().location.y, 0f32);
     assert_eq!(stretch.layout(node0).unwrap().size.width, 200f32);
-    assert_eq!(stretch.layout(node0).unwrap().size.height, 280f32);
+    assert_eq!(stretch.layout(node0).unwrap().size.height, 240f32);
     assert_eq!(stretch.layout(node0).unwrap().location.x, 0f32);
     assert_eq!(stretch.layout(node0).unwrap().location.y, 0f32);
     assert_eq!(stretch.layout(node1).unwrap().size.width, 200f32);
-    assert_eq!(stretch.layout(node1).unwrap().size.height, 120f32);
+    assert_eq!(stretch.layout(node1).unwrap().size.height, 160f32);
     assert_eq!(stretch.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(stretch.layout(node1).unwrap().location.y, 280f32);
+    assert_eq!(stretch.layout(node1).unwrap().location.y, 240f32);
 }


### PR DESCRIPTION
Hi! I re-genertated the chrome compatibility tests and as you can see the measurements have changed. I'm not sure if it's a chrome behaviour change (or a bug) or stretch implementation is wrong, but I'm creating this PR to let you guys know about this.