### PR TITLE
Fix typo in algorithm to correctly accumulate layout location for nested child nodes

### DIFF
--- a/src/algo.rs
+++ b/src/algo.rs
@@ -104,8 +104,8 @@ impl Forest {
         let abs_x = abs_x + layout.location.x;
         let abs_y = abs_y + layout.location.y;
 
-        layout.location.x = sys::round(layout.location.x);
-        layout.location.y = sys::round(layout.location.y);
+        layout.location.x = sys::round(abs_x);
+        layout.location.y = sys::round(abs_y);
         layout.size.width = sys::round(abs_x + layout.size.width) - sys::round(abs_x);
         layout.size.height = sys::round(abs_y + layout.size.height) - sys::round(abs_y);
         for child in &children[root] {


### PR DESCRIPTION
The algorithm for computing layout was (I presume) mistakenly ignoring the location of parent nodes when laying out their children, causing nested child nodes to display from (0,0) even if their parents were located at some offset. 

See an example of this behaviour in #58